### PR TITLE
Fix tags conflict in Dungeon World item/monster templates

### DIFF
--- a/Display/dw/item.html.twig
+++ b/Display/dw/item.html.twig
@@ -6,7 +6,7 @@
     <table class="dw-table">
         <tr>
             <td><span class="name">{{ variables.name }}</span></td>
-            <td class="tags" colspan='2'>{{ variables.tags }}</td>
+            <td class="tags" colspan='2'>{{ variables.dw_tags }}</td>
         </tr>        
         <tr>            
             {% if variables.uses %}

--- a/Display/dw/monster.html.twig
+++ b/Display/dw/monster.html.twig
@@ -2,16 +2,16 @@
 
 {% block body %}
 
-<div class="monster-box">
-    <table class="monster-table">
+<div class="dw-box">
+    <table class="dw-table">
         <tr>
             <td><span class="name">{{ variables.name }}</span></td>
-            <td class="tags" colspan='2'>{{ variables.tags }}</td>
+            <td class="tags" colspan='2'>{{ variables.dw_tags }}</td>
         </tr>        
         <tr>
-            <td class="monster-damage">{{ variables.damage|BBcode }}</td>
+            <td class="dw-damage">{{ variables.damage|BBcode }}</td>
             <td class="monster-hp">{{ variables.hp }} HP</td>
-            <td class="monster-armor">{{ variables.armor }} Armor</td>
+            <td class="dw-armor">{{ variables.armor }} Armor</td>
         </tr>        
         <tr>
             <td class="damage-tags" colspan='3'>{{ variables.damage_tags }}</td>

--- a/Schema/dw/item.yml
+++ b/Schema/dw/item.yml
@@ -15,7 +15,7 @@ fields:
     description: "Item name"
     placeholder: "The Hitchhiker's Guide to the Galaxy"
     required: true
-  tags:
+  dw_tags:
     input: string
     label: "Tags"
     description: "Item tags"

--- a/Schema/dw/monster.yml
+++ b/Schema/dw/monster.yml
@@ -15,7 +15,7 @@ fields:
     description: "Monster's name"
     placeholder: "Carnivorous Butter"
     required: true
-  tags:
+  dw_tags:
     input: string    
     label: "Tags"
     description: "Monster's tags"


### PR DESCRIPTION
This will change the tags entry in item/monster schema and templates to avoid conflict
with World Anvil article tags.
Fixed bug in monster template: wrong class on a couple of divs.