### PR TITLE
GalaxyAnvil v1.2.1

### DIFF
--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -401,40 +401,40 @@
 	min-height: 100px;
 }
 
-.user-css .user-row {
+.user-css .row-border-group .user-row {
     display: flex;
 }
 
-.user-css .user-row .col-md-6 {
+.user-css .row-border-group .user-row .col-md-6 {
     border-left: 1px solid;
     border-right: 1px solid;
 }
 
-.user-css .user-row .col-md-6:first-child {
+.user-css .row-border-group .user-row .col-md-6:first-child {
     border-left: none;
 }
 
-.user-css .user-row .col-md-6:last-child {
+.user-css .row-border-group .user-row .col-md-6:last-child {
     border-right: none;
 }
 
-.user-css .user-row:first-child .col-md-6 {
+.user-css .row-border-group .user-row:first-child .col-md-6 {
     border: none;
 }
 
-.user-css .user-row:last-child .col-md-6 {
+.user-css .row-border-group .user-row:last-child .col-md-6 {
     border: none;
 }
 
-.user-css .user-row .col-md-6:after, .user-css .user-row .col-md-6:before {
+.user-css .row-border-group .user-row .col-md-6:after, .user-css .row-border-group .user-row .col-md-6:before {
     content: url(https://www.worldanvil.com/uploads/images/d4222ca4f7e45bb789519bd04deb8449.gif);
     position: absolute;
 }
 
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after, /* 2-col Middle left cell, top border */
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after, /* 2-col Middle right cell, top border */
-.user-css .user-row:last-child .col-md-6:first-child:before, /* 2-col Bottom left cell, top border */
-.user-css .user-row:last-child .col-md-6:last-child:before /* 2-col Bottom right cell, top border */
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after, /* 2-col Middle left cell, top border */
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after, /* 2-col Middle right cell, top border */
+.user-css .row-border-group .user-row:last-child .col-md-6:first-child:before, /* 2-col Bottom left cell, top border */
+.user-css .row-border-group .user-row:last-child .col-md-6:last-child:before /* 2-col Bottom right cell, top border */
 {
     left: 0;
     right: 0;
@@ -442,10 +442,10 @@
     height: 1px;
 }
 
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before, /* 2-col Middle left cell, bottom border */
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before, /* 2-col Middle right cell, bottom border */
-.user-css .user-row:first-child .col-md-6:first-child:before, /* 2-col Top left cell, bottom border */
-.user-css .user-row:first-child .col-md-6:last-child:before /* 2-col Top right cell, bottom border */
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before, /* 2-col Middle left cell, bottom border */
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before, /* 2-col Middle right cell, bottom border */
+.user-css .row-border-group .user-row:first-child .col-md-6:first-child:before, /* 2-col Top left cell, bottom border */
+.user-css .row-border-group .user-row:first-child .col-md-6:last-child:before /* 2-col Top right cell, bottom border */
 {
     left: 0;
     right: 0;
@@ -453,8 +453,8 @@
     height: 1px;
 }
 
-.user-css .user-row:first-child .col-md-6:first-child:after, /* 2-col Top left cell, right border */
-.user-css .user-row:last-child .col-md-6:first-child:after /* 2-col Bottom left cell, right border */
+.user-css .row-border-group .user-row:first-child .col-md-6:first-child:after, /* 2-col Top left cell, right border */
+.user-css .row-border-group .user-row:last-child .col-md-6:first-child:after /* 2-col Bottom left cell, right border */
 {
     top: 0;
     bottom: 0;
@@ -462,8 +462,8 @@
     width: 1px;
 }
 
-.user-css .user-row:first-child .col-md-6:last-child:after, /* 2-col Top right cell, left border */
-.user-css .user-row:last-child .col-md-6:last-child:after /* 2-col Bottom right cell, left border */
+.user-css .row-border-group .user-row:first-child .col-md-6:last-child:after, /* 2-col Top right cell, left border */
+.user-css .row-border-group .user-row:last-child .col-md-6:last-child:after /* 2-col Bottom right cell, left border */
 {
     top: 0;
     bottom: 0;
@@ -471,7 +471,7 @@
     width: 1px;
 }
 
-.user-css .user-row:only-child .col-md-6:first-child:after { /* 2-col Single row left cell, right border */
+.user-css .row-border-group .user-row:only-child .col-md-6:first-child:after { /* 2-col Single row left cell, right border */
     left: auto;
     right: 0;
     top: 0;
@@ -479,11 +479,11 @@
     width: 1px;
 }
 
-.user-css .user-row:only-child .col-md-6:first-child:before {
+.user-css .row-border-group .user-row:only-child .col-md-6:first-child:before {
     display: none;
 }
 
-.user-css .user-row:only-child .col-md-6:last-child:after { /* 2-col Single row right cell, left border */
+.user-css .row-border-group .user-row:only-child .col-md-6:last-child:after { /* 2-col Single row right cell, left border */
     left: 0;
     right: auto;
     top: 0;
@@ -491,7 +491,7 @@
     width: 1px;
 }
 
-.user-css .user-row:only-child .col-md-6:last-child:before {
+.user-css .row-border-group .user-row:only-child .col-md-6:last-child:before {
     display: none;
 }
 
@@ -838,36 +838,36 @@
 }
 
 /* ROW BORDER GROUP */
-.user-css .user-row .col-md-6 {
+.user-css .row-border-group .user-row .col-md-6 {
     border-color: var(--accentA);
 }
 
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after,
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before,
-.user-css .user-row:first-child .col-md-6:first-child:before,
-.user-css .user-row:last-child .col-md-6:first-child:before {
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after,
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before,
+.user-css .row-border-group .user-row:first-child .col-md-6:first-child:before,
+.user-css .row-border-group .user-row:last-child .col-md-6:first-child:before {
     background-image: linear-gradient(to right, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after,
-.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before,
-.user-css .user-row:first-child .col-md-6:last-child:before,
-.user-css .user-row:last-child .col-md-6:last-child:before {
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after,
+.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before,
+.user-css .row-border-group .user-row:first-child .col-md-6:last-child:before,
+.user-css .row-border-group .user-row:last-child .col-md-6:last-child:before {
     background-image: linear-gradient(to left, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .user-row:first-child .col-md-6:first-child:after,
-.user-css .user-row:first-child .col-md-6:last-child:after {
+.user-css .row-border-group .user-row:first-child .col-md-6:first-child:after,
+.user-css .row-border-group .user-row:first-child .col-md-6:last-child:after {
     background-image: linear-gradient(to bottom, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .user-row:last-child .col-md-6:first-child:after,
-.user-css .user-row:last-child .col-md-6:last-child:after {
+.user-css .row-border-group .user-row:last-child .col-md-6:first-child:after,
+.user-css .row-border-group .user-row:last-child .col-md-6:last-child:after {
     background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .user-row:only-child .col-md-6:first-child:after,
-.user-css .user-row:only-child .col-md-6:last-child:after {
+.user-css .row-border-group .user-row:only-child .col-md-6:first-child:after,
+.user-css .row-border-group .user-row:only-child .col-md-6:last-child:after {
     background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--accentA), var(--defaultAFullTransparent));
 }
 

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1,6 +1,6 @@
 /*
  * GalaxyAnvil - A theme for WorldAnvil, created by SierraKomodo
- * Version 1.1.0
+ * Version 1.1.1
  * https://github.com/SierraKomodo/worldanvil-templates/tree/GalaxyAnvil
  */
 

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -839,36 +839,36 @@
 
 /* ROW BORDER GROUP */
 .user-css .row-border-group .user-row .col-md-6 {
-    border-color: var(--defaultA);
+    border-color: var(--accentA);
 }
 
 .user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after,
 .user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before,
 .user-css .row-border-group .user-row:first-child .col-md-6:first-child:before,
 .user-css .row-border-group .user-row:last-child .col-md-6:first-child:before {
-    background-image: linear-gradient(to right, var(--defaultAFullTransparent), var(--defaultA));
+    background-image: linear-gradient(to right, var(--defaultAFullTransparent), var(--accentA));
 }
 
 .user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after,
 .user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before,
 .user-css .row-border-group .user-row:first-child .col-md-6:last-child:before,
 .user-css .row-border-group .user-row:last-child .col-md-6:last-child:before {
-    background-image: linear-gradient(to left, var(--defaultAFullTransparent), var(--defaultA));
+    background-image: linear-gradient(to left, var(--defaultAFullTransparent), var(--accentA));
 }
 
 .user-css .row-border-group .user-row:first-child .col-md-6:first-child:after,
 .user-css .row-border-group .user-row:first-child .col-md-6:last-child:after {
-    background-image: linear-gradient(to bottom, var(--defaultAFullTransparent), var(--defaultA));
+    background-image: linear-gradient(to bottom, var(--defaultAFullTransparent), var(--accentA));
 }
 
 .user-css .row-border-group .user-row:last-child .col-md-6:first-child:after,
 .user-css .row-border-group .user-row:last-child .col-md-6:last-child:after {
-    background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--defaultA));
+    background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--accentA));
 }
 
 .user-css .row-border-group .user-row:only-child .col-md-6:first-child:after,
 .user-css .row-border-group .user-row:only-child .col-md-6:last-child:after {
-    background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--defaultA), var(--defaultAFullTransparent));
+    background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--accentA), var(--defaultAFullTransparent));
 }
 
 /* SPOILERS */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -924,9 +924,19 @@
     color: var(--accentA);
 }
 
+/* IMAGES */
 .user-css .artist-credits {
-    background: var(--primary3Transparent);
-    color: var(--primaryDMuted);
+    background: var(--accent5Transparent);
+    color: var(--accentDMuted);
+}
+
+.user-css .user-css-image-thumbnail, .user-css-extended .user-css-image-thumbnail {
+	background: var(--accent5Transparent);
+}
+
+.user-css .user-css-image-thumbnail .artist-credits, .user-css-extended .user-css-image-thumbnail .artist-credits {
+	background: var(--primary5Transparent);
+	color: var(--primaryDMuted);
 }
 
 /* TIMELINES */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -401,40 +401,40 @@
 	min-height: 100px;
 }
 
-.user-css .row-border-group .user-row {
+.user-css .user-row {
     display: flex;
 }
 
-.user-css .row-border-group .user-row .col-md-6 {
+.user-css .user-row .col-md-6 {
     border-left: 1px solid;
     border-right: 1px solid;
 }
 
-.user-css .row-border-group .user-row .col-md-6:first-child {
+.user-css .user-row .col-md-6:first-child {
     border-left: none;
 }
 
-.user-css .row-border-group .user-row .col-md-6:last-child {
+.user-css .user-row .col-md-6:last-child {
     border-right: none;
 }
 
-.user-css .row-border-group .user-row:first-child .col-md-6 {
+.user-css .user-row:first-child .col-md-6 {
     border: none;
 }
 
-.user-css .row-border-group .user-row:last-child .col-md-6 {
+.user-css .user-row:last-child .col-md-6 {
     border: none;
 }
 
-.user-css .row-border-group .user-row .col-md-6:after, .user-css .row-border-group .user-row .col-md-6:before {
+.user-css .user-row .col-md-6:after, .user-css .user-row .col-md-6:before {
     content: url(https://www.worldanvil.com/uploads/images/d4222ca4f7e45bb789519bd04deb8449.gif);
     position: absolute;
 }
 
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after, /* 2-col Middle left cell, top border */
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after, /* 2-col Middle right cell, top border */
-.user-css .row-border-group .user-row:last-child .col-md-6:first-child:before, /* 2-col Bottom left cell, top border */
-.user-css .row-border-group .user-row:last-child .col-md-6:last-child:before /* 2-col Bottom right cell, top border */
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after, /* 2-col Middle left cell, top border */
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after, /* 2-col Middle right cell, top border */
+.user-css .user-row:last-child .col-md-6:first-child:before, /* 2-col Bottom left cell, top border */
+.user-css .user-row:last-child .col-md-6:last-child:before /* 2-col Bottom right cell, top border */
 {
     left: 0;
     right: 0;
@@ -442,10 +442,10 @@
     height: 1px;
 }
 
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before, /* 2-col Middle left cell, bottom border */
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before, /* 2-col Middle right cell, bottom border */
-.user-css .row-border-group .user-row:first-child .col-md-6:first-child:before, /* 2-col Top left cell, bottom border */
-.user-css .row-border-group .user-row:first-child .col-md-6:last-child:before /* 2-col Top right cell, bottom border */
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before, /* 2-col Middle left cell, bottom border */
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before, /* 2-col Middle right cell, bottom border */
+.user-css .user-row:first-child .col-md-6:first-child:before, /* 2-col Top left cell, bottom border */
+.user-css .user-row:first-child .col-md-6:last-child:before /* 2-col Top right cell, bottom border */
 {
     left: 0;
     right: 0;
@@ -453,8 +453,8 @@
     height: 1px;
 }
 
-.user-css .row-border-group .user-row:first-child .col-md-6:first-child:after, /* 2-col Top left cell, right border */
-.user-css .row-border-group .user-row:last-child .col-md-6:first-child:after /* 2-col Bottom left cell, right border */
+.user-css .user-row:first-child .col-md-6:first-child:after, /* 2-col Top left cell, right border */
+.user-css .user-row:last-child .col-md-6:first-child:after /* 2-col Bottom left cell, right border */
 {
     top: 0;
     bottom: 0;
@@ -462,8 +462,8 @@
     width: 1px;
 }
 
-.user-css .row-border-group .user-row:first-child .col-md-6:last-child:after, /* 2-col Top right cell, left border */
-.user-css .row-border-group .user-row:last-child .col-md-6:last-child:after /* 2-col Bottom right cell, left border */
+.user-css .user-row:first-child .col-md-6:last-child:after, /* 2-col Top right cell, left border */
+.user-css .user-row:last-child .col-md-6:last-child:after /* 2-col Bottom right cell, left border */
 {
     top: 0;
     bottom: 0;
@@ -471,7 +471,7 @@
     width: 1px;
 }
 
-.user-css .row-border-group .user-row:only-child .col-md-6:first-child:after { /* 2-col Single row left cell, right border */
+.user-css .user-row:only-child .col-md-6:first-child:after { /* 2-col Single row left cell, right border */
     left: auto;
     right: 0;
     top: 0;
@@ -479,11 +479,11 @@
     width: 1px;
 }
 
-.user-css .row-border-group .user-row:only-child .col-md-6:first-child:before {
+.user-css .user-row:only-child .col-md-6:first-child:before {
     display: none;
 }
 
-.user-css .row-border-group .user-row:only-child .col-md-6:last-child:after { /* 2-col Single row right cell, left border */
+.user-css .user-row:only-child .col-md-6:last-child:after { /* 2-col Single row right cell, left border */
     left: 0;
     right: auto;
     top: 0;
@@ -491,7 +491,7 @@
     width: 1px;
 }
 
-.user-css .row-border-group .user-row:only-child .col-md-6:last-child:before {
+.user-css .user-row:only-child .col-md-6:last-child:before {
     display: none;
 }
 
@@ -838,36 +838,36 @@
 }
 
 /* ROW BORDER GROUP */
-.user-css .row-border-group .user-row .col-md-6 {
+.user-css .user-row .col-md-6 {
     border-color: var(--accentA);
 }
 
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after,
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before,
-.user-css .row-border-group .user-row:first-child .col-md-6:first-child:before,
-.user-css .row-border-group .user-row:last-child .col-md-6:first-child:before {
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:after,
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before,
+.user-css .user-row:first-child .col-md-6:first-child:before,
+.user-css .user-row:last-child .col-md-6:first-child:before {
     background-image: linear-gradient(to right, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after,
-.user-css .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before,
-.user-css .row-border-group .user-row:first-child .col-md-6:last-child:before,
-.user-css .row-border-group .user-row:last-child .col-md-6:last-child:before {
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after,
+.user-css .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before,
+.user-css .user-row:first-child .col-md-6:last-child:before,
+.user-css .user-row:last-child .col-md-6:last-child:before {
     background-image: linear-gradient(to left, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .row-border-group .user-row:first-child .col-md-6:first-child:after,
-.user-css .row-border-group .user-row:first-child .col-md-6:last-child:after {
+.user-css .user-row:first-child .col-md-6:first-child:after,
+.user-css .user-row:first-child .col-md-6:last-child:after {
     background-image: linear-gradient(to bottom, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .row-border-group .user-row:last-child .col-md-6:first-child:after,
-.user-css .row-border-group .user-row:last-child .col-md-6:last-child:after {
+.user-css .user-row:last-child .col-md-6:first-child:after,
+.user-css .user-row:last-child .col-md-6:last-child:after {
     background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--accentA));
 }
 
-.user-css .row-border-group .user-row:only-child .col-md-6:first-child:after,
-.user-css .row-border-group .user-row:only-child .col-md-6:last-child:after {
+.user-css .user-row:only-child .col-md-6:first-child:after,
+.user-css .user-row:only-child .col-md-6:last-child:after {
     background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--accentA), var(--defaultAFullTransparent));
 }
 


### PR DESCRIPTION
# Version 1.2.1 Changelog
## Added
 - Basic statblock support to prevent white text on white backgrounds. Some statblocks were overriding this in testing so this isn't complete.

## Changed
 - Darkened the color of `.text-abbreviation` - This results in tooltip text being darker than link text to make them easier to differentiate.
 - All CSS now applies only to presentation and not the editor. Editor themeing support to come later.
 - Table row highlight color has been darkened and changed to the primary color to improve readability.