### PR TITLE
GalaxyAnvil v1.2.4

### DIFF
--- a/themes/galaxyanvil/ABOUT.MD
+++ b/themes/galaxyanvil/ABOUT.MD
@@ -1,5 +1,5 @@
 # GalaxyAnvil
-Version: 1.2.3
+Version: 1.2.4
 
 A theme for WorldAnvil, created by SierraKomodo.
 

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.4] - 2018-01-22
+### Added
+ - This changelog.
+ - Support for `.col-md-12` to `.row-border-group`
+   - This allows borders to be added to `[container:col-md-12]` blocks that span an entire row.
+ - Support for `.panel-npcsheet`
+
+### Changed
+ - Colors used for horizontal rules (`[hr]`)
+   - `hr` now uses `default` color
+   - `hr` contained in `.panel-primary` and `.panel-npcsheet` now uses `primary` color
+ - Darkened the background for `.aloud` (`[aloud]`) blocks
+   - Improves readability of tooltip and link text with certain color schemes
+
+### Fixed 
+ - Background gradient was stronger on some pages

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1,6 +1,6 @@
 /*
  * GalaxyAnvil - A theme for WorldAnvil, created by SierraKomodo
- * Version 1.2.3
+ * Version 1.2.4
  * https://github.com/SierraKomodo/worldanvil-templates/tree/GalaxyAnvil
  */
 
@@ -605,7 +605,7 @@
     background-attachment: fixed;
 }
 
-.user-css-presentation .page::after {
+.user-css-presentation::after {
     content: url(../images/empty.gif);
     background: var(--default1);
     background: linear-gradient(to right, var(--primary3), var(--accent3), var(--default1), var(--default1), var(--default1), var(--accent3), var(--primary3));

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -145,7 +145,6 @@
     border-left: 34px solid;
     font-size: 13px;
     padding: 5px 10px;
-    padding-left: 10px;
     text-align: justify;
     width: 85%;
     margin-left: auto;
@@ -205,7 +204,7 @@
     border-bottom: none;
 }
 
-.user-css-presentation .panel {
+.user-css-presentation .panel, .user-css-presentation .panel-npcsheet {
     margin-bottom: 20px;
     border: none;
     border-radius: 4px;
@@ -364,7 +363,7 @@
     padding: 3px 5px;
 }
 
-/* Temporary hotfix for character shete readability */
+/* Temporary hotfix for character sheet readability */
 .user-css-presentation .character-sheet {
     color: black;
 }
@@ -434,7 +433,6 @@
 }
 
 .user-css-presentation .glossary-block .article-panel {
-    flex-basis: 33.3%;
     margin-left: 7.5px;
     margin-right: 7.5px;
     flex: 0 1 calc(33.3% - 15px);
@@ -473,11 +471,9 @@
     border-right: none;
 }
 
-.user-css-presentation .row-border-group .user-row:first-child .col-md-6 {
-    border: none;
-}
-
-.user-css-presentation .row-border-group .user-row:last-child .col-md-6 {
+.user-css-presentation .row-border-group .user-row:first-child .col-md-6,
+.user-css-presentation .row-border-group .user-row:last-child .col-md-6,
+.user-css-presentation .row-border-group .user-row .col-md-12 {
     border: none;
 }
 
@@ -506,7 +502,8 @@
 }
 
 .user-css-presentation .row-border-group .user-row .col-md-6:after, .user-css-presentation .row-border-group .user-row .col-md-6:before,
-.user-css-presentation .row-border-group .user-row .col-md-4:after, .user-css-presentation .row-border-group .user-row .col-md-4:before
+.user-css-presentation .row-border-group .user-row .col-md-4:after, .user-css-presentation .row-border-group .user-row .col-md-4:before,
+.user-css-presentation .row-border-group .user-row .col-md-12:after
 {
     content: url(https://www.worldanvil.com/uploads/images/d4222ca4f7e45bb789519bd04deb8449.gif);
     position: absolute;
@@ -519,7 +516,8 @@
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:first-child:after, /* 3-col Middle left cell, top border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:last-child:after, /* 3-col Middle right cell, top border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4:first-child:before, /* 3-col Bottom left cell, top border */
-.user-css-presentation .row-border-group .user-row:last-child .col-md-4:last-child:before /* 3-col Bottom right cell, top border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-4:last-child:before, /* 3-col Bottom right cell, top border */
+.user-css-presentation .row-border-group .user-row:not(:first-child) .col-md-12:after /* 1-col bottom cells, top border */
 {
     left: 0;
     right: 0;
@@ -534,7 +532,8 @@
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:first-child:before, /* 3-col Middle left cell, bottom border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:last-child:before, /* 3-col Middle right cell, bottom border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:first-child:before, /* 3-col Top left cell, bottom border */
-.user-css-presentation .row-border-group .user-row:first-child .col-md-4:last-child:before /* 3-col Top right cell, bottom border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-4:last-child:before, /* 3-col Top right cell, bottom border */
+.user-css-presentation .row-border-group .user-row:not(:last-child) .col-md-12:after /* 1-col upper cells, bottom border */
 {
     left: 0;
     right: 0;
@@ -695,7 +694,7 @@
 
 /* HORIZONTAL RULES */
 .user-css-presentation hr {
-    border-color: var(--accentA);
+    border-color: var(--defaultA);
 }
 
 /* LINKS */
@@ -775,7 +774,7 @@
 
 /* ALOUD */
 .user-css-presentation .aloud {
-    background: var(--default5Transparent);
+    background: var(--default4Transparent);
     color: var(--defaultDMuted);
     box-shadow: 0 0 2px 2px var(--defaultATransparent);
 }
@@ -1015,11 +1014,15 @@
     color: var(--accentCMuted);
 }
 
-.user-css-presentation .panel-primary {
+.user-css-presentation .panel-primary, .user-css-presentation .panel-npcsheet {
     background-color: var(--primary3Transparent);
     border-color: var(--primaryDTransparent);
     color: var(--primaryDMuted);
     box-shadow: 0 0 2px 2px var(--primaryDTransparent);
+}
+
+.user-css-presentation .panel-primary hr, .user-css-presentation .panel-npcsheet hr {
+    border-color: var(--primaryA);
 }
 
 .user-css-presentation .panel-primary .panel-heading {
@@ -1109,6 +1112,12 @@
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:not(:first-child):not(:last-child):before /* 3-col Single row middle cell, left border */
 {
     background-image: linear-gradient(to top, var(--defaultAFullTransparent), var(--accentA), var(--defaultAFullTransparent));
+}
+
+.user-css-presentation .row-border-group .user-row:not(:first-child) .col-md-12:after, /* 1-col upper cells, bottom border */
+.user-css-presentation .row-border-group .user-row:not(:last-child) .col-md-12:after /* 1-col bottom cells, top border */
+{
+    background-image: linear-gradient(to left, var(--defaultAFullTransparent), var(--accentA), var(--defaultAFullTransparent));
 }
 
 /* SPOILERS */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -604,7 +604,7 @@
     background-attachment: fixed;
 }
 
-.user-css-presentation::after {
+.user-css-presentation .user-css.page::after {
     content: url(../images/empty.gif);
     background: var(--default1);
     background: linear-gradient(to right, var(--primary3), var(--accent3), var(--default1), var(--default1), var(--default1), var(--accent3), var(--primary3));


### PR DESCRIPTION
## [1.2.4] - 2018-01-22
### Added
 - This changelog.
 - Support for `.col-md-12` to `.row-border-group`
   - This allows borders to be added to `[container:col-md-12]` blocks that span an entire row.
 - Support for `.panel-npcsheet`

### Changed
 - Colors used for horizontal rules (`[hr]`)
   - `hr` now uses `default` color
   - `hr` contained in `.panel-primary` and `.panel-npcsheet` now uses `primary` color
 - Darkened the background for `.aloud` (`[aloud]`) blocks
   - Improves readability of tooltip and link text with certain color schemes

### Fixed 
 - Background gradient was stronger on some pages