### PR TITLE
Galaxy Anvil v1.3.0

### DIFF
--- a/themes/galaxyanvil/ABOUT.MD
+++ b/themes/galaxyanvil/ABOUT.MD
@@ -1,5 +1,5 @@
 # GalaxyAnvil
-Version: 1.2.4
+Version: 1.3.0
 
 A theme for WorldAnvil, created by SierraKomodo.
 

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2018-07-14
+### Added
+ - New Inline version of GalaxyAnvil, intended for copy+pasta use in your world's CSS box if preferred over the WorldAnvil theme selection. See Releases for CSS file and more details.
+ - Support for `.card-box` classes
+ - borderRadius variables for easier customization
+
+### Fixed
+ - Buttons in world header cover not rendering correctly
+
+### Changed
+ - Various tweaks and changes to incorporate the 2018 theme update's changes.
+ - World menu and map boxes now use accent colors instead of primary.
+ - Tweaked font sizes of various elements to improve readability.
+ - Restyled timeline panels
+
 ## [1.2.5] - 2018-05-14
 ### Fixed
  - Fixed the 'Follow' button in world headers displaying as a big, empty green box.
@@ -22,5 +37,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Darkened the background for `.aloud` (`[aloud]`) blocks
    - Improves readability of tooltip and link text with certain color schemes
 
-### Fixed 
+### Fixed
  - Background gradient was stronger on some pages

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - Tweaked small and muted text color to improve readability.
 
+### Fixed
+ - Search icon color not overriding default WA styles in inline version.
+
 ## [1.3.0] - 2018-07-14
 ### Added
  - New Inline version of GalaxyAnvil, intended for copy+pasta use in your world's CSS box if preferred over the WorldAnvil theme selection. See Releases for CSS file and more details.

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+### Added
+ - Support for WorldAnvil's new world presentation front page
+
 ### Changed
  - Tweaked small and muted text color to improve readability.
 

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - Search icon color not overriding default WA styles in inline version.
+ - Tag labels in timelines not being colored.
 
 ## [1.3.0] - 2018-07-14
 ### Added

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - Buttons in world header cover not rendering correctly
+ - Image background not rendering
+ - Artist credit links using wrong color
 
 ### Changed
  - Various tweaks and changes to incorporate the 2018 theme update's changes.

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Changed
+ - Tweaked small and muted text color to improve readability.
+
 ## [1.3.0] - 2018-07-14
 ### Added
  - New Inline version of GalaxyAnvil, intended for copy+pasta use in your world's CSS box if preferred over the WorldAnvil theme selection. See Releases for CSS file and more details.

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1,6 +1,6 @@
 /*
  * GalaxyAnvil - A theme for WorldAnvil, created by SierraKomodo
- * Version indev-fix-galaxyanvil-header-follow-button
+ * Version 1.2.5-inline
  * https://github.com/SierraKomodo/worldanvil-templates/tree/GalaxyAnvil
  */
 
@@ -509,7 +509,7 @@
 .user-css-presentation .row-border-group .user-row .col-md-4:after, .user-css-presentation .row-border-group .user-row .col-md-4:before,
 .user-css-presentation .row-border-group .user-row .col-md-12:after
 {
-    content: url(https://www.worldanvil.com/uploads/images/d4222ca4f7e45bb789519bd04deb8449.gif);
+    content: url(https://www.worldanvil.com/themes/galaxyanvil/images/empty.gif);
     position: absolute;
 }
 
@@ -604,12 +604,12 @@
 /* THEME APPLICATION */
 .user-css-presentation {
     background-color: black;
-    background-image: url(../images/background.jpg);
+    background-image: url(https://www.worldanvil.com/themes/galaxyanvil/images/background.jpg);
     background-attachment: fixed;
 }
 
 .user-css-presentation .user-css.page::after {
-    content: url(../images/empty.gif);
+    content: url(https://www.worldanvil.com/themes/galaxyanvil/images/empty.gif);
     background: var(--default1);
     background: linear-gradient(to right, var(--primary3), var(--accent3), var(--default1), var(--default1), var(--default1), var(--accent3), var(--primary3));
     opacity: 0.3;

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -2539,7 +2539,7 @@
 }
 
 .user-css-secret small, .user-css-secret .text-muted {
-    color: var(--primary8Muted);
+    color: var(--primaryCMuted);
 }
 
 /* SPOILERS */
@@ -2666,19 +2666,19 @@
 /* SMALL/TEXT_Muted */
 .user-css-presentation small,
 .user-css-presentation .text-muted {
-    color: var(--default8Muted);
+    color: var(--defaultCMuted);
 }
 
 .user-css-presentation .panel-default small,
 .user-css-presentation .panel-default .text-muted,
 .user-css-presentation .spoiler-content small,
 .user-css-presentation .spoiler-content .text-muted {
-    color: var(--accent8Muted);
+    color: var(--accentCMuted);
 }
 
 .user-css-presentation .panel-primary small,
 .user-css-presentation .panel-primary .text-muted {
-    color: var(--primary8Muted);
+    color: var(--primaryCMuted);
 }
 
 /* WELLS */
@@ -2721,9 +2721,9 @@
     --tlBackground3Transparent: var(--accent3Transparent);
     --tlBorder: var(--accentA);
     --tlColor: var(--accentDMuted);
-    --tlColorMuted: var(--accent8Muted);
+    --tlColorMuted: var(--accentCMuted);
     --tlColorHeader: var(--accentA);
-    --tlColorHeaderMuted: var(--accent8Muted);
+    --tlColorHeaderMuted: var(--accentCMuted);
 }
 
 .user-css-presentation .timeline li.milestone {
@@ -2732,9 +2732,9 @@
     --tlBackground3Transparent: var(--primary3Transparent);
     --tlBorder: var(--primaryA);
     --tlColor: var(--primaryDMuted);
-    --tlColorMuted: var(--primary8Muted);
+    --tlColorMuted: var(--primaryCMuted);
     --tlColorHeader: var(--primaryA);
-    --tlColorHeaderMuted: var(--primary8Muted);
+    --tlColorHeaderMuted: var(--primaryCMuted);
 }
 
 .user-css-presentation .timeline li.important {
@@ -2743,9 +2743,9 @@
     --tlBackground3Transparent: var(--warning3Transparent);
     --tlBorder: var(--warningA);
     --tlColor: var(--warningDMuted);
-    --tlColorMuted: var(--warning8Muted);
+    --tlColorMuted: var(--warningCMuted);
     --tlColorHeader: var(--warningA);
-    --tlColorHeaderMuted: var(--warning8Muted);
+    --tlColorHeaderMuted: var(--warningCMuted);
 }
 
 .user-css-presentation .timeline li.major {
@@ -2754,9 +2754,9 @@
     --tlBackground3Transparent: var(--danger3Transparent);
     --tlBorder: var(--dangerA);
     --tlColor: var(--dangerDMuted);
-    --tlColorMuted: var(--danger8Muted);
+    --tlColorMuted: var(--dangerCMuted);
     --tlColorHeader: var(--dangerA);
-    --tlColorHeaderMuted: var(--danger8Muted);
+    --tlColorHeaderMuted: var(--dangerCMuted);
 }
 
 .user-css-presentation .timeline li.minor {
@@ -2765,9 +2765,9 @@
     --tlBackground3Transparent: var(--success3Transparent);
     --tlBorder: var(--successA);
     --tlColor: var(--successDMuted);
-    --tlColorMuted: var(--success8Muted);
+    --tlColorMuted: var(--successCMuted);
     --tlColorHeader: var(--successA);
-    --tlColorHeaderMuted: var(--success8Muted);
+    --tlColorHeaderMuted: var(--successCMuted);
 }
 
 .user-css-presentation .timeline li.trivial {
@@ -2776,9 +2776,9 @@
     --tlBackground3Transparent: var(--info3Transparent);
     --tlBorder: var(--infoA);
     --tlColor: var(--infoDMuted);
-    --tlColorMuted: var(--info8Muted);
+    --tlColorMuted: var(--infoCMuted);
     --tlColorHeader: var(--infoA);
-    --tlColorHeaderMuted: var(--info8Muted);
+    --tlColorHeaderMuted: var(--infoCMuted);
 }
 
 .user-css-presentation .timeline li .tl-circ {

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -2720,66 +2720,78 @@
     --tlBackground: var(--accent1Muted);
     --tlBackground3: var(--accent3);
     --tlBackground3Transparent: var(--accent3Transparent);
+    --tlBackgroundTag: var(--accentAMuted);
     --tlBorder: var(--accentA);
     --tlColor: var(--accentDMuted);
     --tlColorMuted: var(--accentCMuted);
     --tlColorHeader: var(--accentA);
     --tlColorHeaderMuted: var(--accentCMuted);
+    --tlColorTag: var(--accent3Muted);
 }
 
 .user-css-presentation .timeline li.milestone {
     --tlBackground: var(--primary1Muted);
     --tlBackground3: var(--primary3);
     --tlBackground3Transparent: var(--primary3Transparent);
+    --tlBackgroundTag: var(--primaryAMuted);
     --tlBorder: var(--primaryA);
     --tlColor: var(--primaryDMuted);
     --tlColorMuted: var(--primaryCMuted);
     --tlColorHeader: var(--primaryA);
     --tlColorHeaderMuted: var(--primaryCMuted);
+    --tlColorTag: var(--primary3Muted);
 }
 
 .user-css-presentation .timeline li.important {
     --tlBackground: var(--warning1Muted);
     --tlBackground3: var(--warning3);
     --tlBackground3Transparent: var(--warning3Transparent);
+    --tlBackgroundTag: var(--warningAMuted);
     --tlBorder: var(--warningA);
     --tlColor: var(--warningDMuted);
     --tlColorMuted: var(--warningCMuted);
     --tlColorHeader: var(--warningA);
     --tlColorHeaderMuted: var(--warningCMuted);
+    --tlColorTag: var(--warning3Muted);
 }
 
 .user-css-presentation .timeline li.major {
     --tlBackground: var(--danger1Muted);
     --tlBackground3: var(--danger3);
     --tlBackground3Transparent: var(--danger3Transparent);
+    --tlBackgroundTag: var(--dangerAMuted);
     --tlBorder: var(--dangerA);
     --tlColor: var(--dangerDMuted);
     --tlColorMuted: var(--dangerCMuted);
     --tlColorHeader: var(--dangerA);
     --tlColorHeaderMuted: var(--dangerCMuted);
+    --tlColorTag: var(--danger3Muted);
 }
 
 .user-css-presentation .timeline li.minor {
     --tlBackground: var(--success1Muted);
     --tlBackground3: var(--success3);
     --tlBackground3Transparent: var(--success3Transparent);
+    --tlBackgroundTag: var(--successAMuted);
     --tlBorder: var(--successA);
     --tlColor: var(--successDMuted);
     --tlColorMuted: var(--successCMuted);
     --tlColorHeader: var(--successA);
     --tlColorHeaderMuted: var(--successCMuted);
+    --tlColorTag: var(--success3Muted);
 }
 
 .user-css-presentation .timeline li.trivial {
     --tlBackground: var(--info1Muted);
     --tlBackground3: var(--info3);
     --tlBackground3Transparent: var(--info3Transparent);
+    --tlBackgroundTag: var(--infoAMuted);
     --tlBorder: var(--infoA);
     --tlColor: var(--infoDMuted);
     --tlColorMuted: var(--infoCMuted);
     --tlColorHeader: var(--infoA);
     --tlColorHeaderMuted: var(--infoCMuted);
+    --tlColorTag: var(--info3Muted);
 }
 
 .user-css-presentation .timeline li .tl-circ {
@@ -2849,6 +2861,12 @@
 .user-css-presentation .timeline li.milestone small,
 .user-css-presentation .timeline li.milestone .text-muted {
     color: var(--tlColorMuted);
+}
+
+.user-css-presentation .timeline li .timeline-panel a.label-default,
+.user-css-presentation .timeline li.milestone a.label-default {
+    background: var(--tlBackgroundTag);
+    color: var(--tlColorTag);
 }
 
 /* TEXT */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1688,6 +1688,26 @@
     margin-right: auto;
 }
 
+.user-css-presentation #world-menu-selector {
+    min-height: 91px;
+}
+
+.user-css-presentation .world-menu-selector-column {
+    padding: 6px;
+}
+
+.user-css-presentation .world-menu-selector-column .world-nav-button {
+    border-radius: var(--borderRadius);
+}
+
+.user-css-presentation .world-menu-selector-column .world-nav-button:hover {
+    text-decoration: none;
+}
+
+.user-css-presentation .world-menu-selector-column .world-nav-button.active {
+    cursor: default;
+}
+
 /* LAYOUT - CUSTOM CLASSES */
 .user-css-presentation .block {
     display: block;
@@ -2687,6 +2707,24 @@
     background-color: var(--accent5Transparent);
     color: var(--accentDMuted);
     box-shadow: 0 0 2px 2px var(--accentATransparent);
+}
+
+/* WORLD MENU SELECTOR */
+.user-css-presentation .world-menu-selector-column .world-nav-button {
+    background: var(--accent5Transparent);
+    color: var(--accentDMuted);
+    box-shadow: 0 0 2px 2px var(--accent5Transparent);
+}
+
+.user-css-presentation .world-menu-selector-column .world-nav-button:hover {
+    background: var(--accent6Transparent);
+    box-shadow: 0 0 2px 2px var(--accentATransparent);
+}
+
+.user-css-presentation .world-menu-selector-column .world-nav-button.active {
+    background: var(--primary6Transparent);
+    color: var(--primaryDMuted);
+    box-shadow: 0 0 2px 2px var(--primaryATransparent);
 }
 
 /* FORM INPUTS */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1986,7 +1986,8 @@
 .user-css-presentation a:focus,
 .user-css-presentation .user-css-image-thumbnail .artist-credits a,
 .user-css-presentation .timeline li .timeline-panel a:not(.label),
-.user-css-presentation .timeline li .milestone-panel a:not(.label) {
+.user-css-presentation .timeline li .milestone-panel a:not(.label),
+.user-css-presentation div.artist-credits a {
     color: var(--primaryD);
 }
 

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -2037,7 +2037,7 @@
 }
 
 .user-css-presentation .alert-default h5:first-child {
-    color: var(--defaultDMuted);
+    color: var(--default3);
 }
 
 .user-css-presentation .alert-primary {
@@ -2048,7 +2048,7 @@
 }
 
 .user-css-presentation .alert-primary h5:first-child {
-    color: var(--primaryDMuted);
+    color: var(--primary3);
 }
 
 .user-css-presentation .alert-secondary {
@@ -2059,7 +2059,7 @@
 }
 
 .user-css-presentation .alert-secondary h5:first-child {
-    color: var(--accentDMuted);
+    color: var(--accent3);
 }
 
 .user-css-presentation .alert-info {
@@ -2070,7 +2070,7 @@
 }
 
 .user-css-presentation .alert-info h5:first-child {
-    color: var(--infoDMuted);
+    color: var(--info3);
 }
 
 .user-css-presentation .alert-success {
@@ -2081,7 +2081,7 @@
 }
 
 .user-css-presentation .alert-success h5:first-child {
-    color: var(--successDMuted);
+    color: var(--success3);
 }
 
 .user-css-presentation .alert-warning {
@@ -2092,7 +2092,7 @@
 }
 
 .user-css-presentation .alert-warning h5:first-child {
-    color: var(--warningDMuted);
+    color: var(--warning3);
 }
 
 .user-css-presentation .alert-danger {
@@ -2103,7 +2103,7 @@
 }
 
 .user-css-presentation .alert-danger h5:first-child {
-    color: var(--dangerDMuted);
+    color: var(--danger3);
 }
 
 /* ALOUD */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1,8 +1,1090 @@
 /*
  * GalaxyAnvil - A theme for WorldAnvil, created by SierraKomodo
- * Version 1.2.5-inline
+ * Version 1.3.0
  * https://github.com/SierraKomodo/worldanvil-templates/tree/GalaxyAnvil
  */
+
+/* Color Theme: Default (Midnight Dusk) */
+.user-css-presentation .user-css, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
+    /* Default Color: Muted Blue (Hue 65) */
+    --default1: #111121;
+    --default2: #222232;
+    --default3: #333343;
+    --default4: #444454;
+    --default5: #555565;
+    --default6: #666676;
+    --default7: #777787;
+    --default8: #888898;
+    --default9: #9999A9;
+    --defaultA: #AAAABA;
+    --defaultB: #BBBBCB;
+    --defaultC: #CCCCDC;
+    --defaultD: #DDDDED;
+    --defaultE: #EEEEFE;
+
+    --default1Muted: #111121;
+    --default2Muted: #222232;
+    --default3Muted: #333343;
+    --default4Muted: #444454;
+    --default5Muted: #555565;
+    --default6Muted: #666676;
+    --default7Muted: #777787;
+    --default8Muted: #888898;
+    --default9Muted: #9999A9;
+    --defaultAMuted: #AAAABA;
+    --defaultBMuted: #BBBBCB;
+    --defaultCMuted: #CCCCDC;
+    --defaultDMuted: #DDDDED;
+    --defaultEMuted: #EEEEFE;
+
+    --default1Transparent: rgba(17, 17, 33, 0.5);
+    --default2Transparent: rgba(34, 34, 50, 0.5);
+    --default3Transparent: rgba(51, 51, 67, 0.5);
+    --default4Transparent: rgba(68, 68, 84, 0.5);
+    --default5Transparent: rgba(85, 85, 101, 0.5);
+    --default6Transparent: rgba(102, 102, 118, 0.5);
+    --default7Transparent: rgba(119, 119, 135, 0.5);
+    --default8Transparent: rgba(136, 136, 152, 0.5);
+    --default9Transparent: rgba(153, 153, 169, 0.5);
+    --defaultATransparent: rgba(170, 170, 186, 0.5);
+    --defaultBTransparent: rgba(187, 187, 203, 0.5);
+    --defaultCTransparent: rgba(204, 204, 220, 0.5);
+    --defaultDTransparent: rgba(221, 221, 237, 0.5);
+    --defaultETransparent: rgba(238, 238, 254, 0.5);
+
+    /* Primary Color: Red-Orange (Hue 10, Sat 100) */
+    --primary1: #112111;
+    --primary2: #193019;
+    --primary3: #224222;
+    --primary4: #2A512A;
+    --primary5: #336333;
+    --primary6: #3C753C;
+    --primary7: #448444;
+    --primary8: #4E964E;
+    --primary9: #57A857;
+    --primaryA: #5FB75F;
+    --primaryB: #68C968;
+    --primaryC: #72DB72;
+    --primaryD: #79EA79;
+    --primaryE: #83FC83;
+
+    --primary1Muted: #112111;
+    --primary2Muted: #223222;
+    --primary3Muted: #334333;
+    --primary4Muted: #445444;
+    --primary5Muted: #556555;
+    --primary6Muted: #667666;
+    --primary7Muted: #778777;
+    --primary8Muted: #889888;
+    --primary9Muted: #99a999;
+    --primaryAMuted: #aabaaa;
+    --primaryBMuted: #bbcbbb;
+    --primaryCMuted: #ccdccc;
+    --primaryDMuted: #ddeddd;
+    --primaryEMuted: #eefeee;
+
+    --primary1Transparent: rgba(17, 33, 17, 0.5);
+    --primary2Transparent: rgba(25, 48, 25, 0.5);
+    --primary3Transparent: rgba(34, 66, 34, 0.5);
+    --primary4Transparent: rgba(42, 81, 42, 0.5);
+    --primary5Transparent: rgba(51, 99, 51, 0.5);
+    --primary6Transparent: rgba(60, 117, 60, 0.5);
+    --primary7Transparent: rgba(68, 132, 68, 0.5);
+    --primary8Transparent: rgba(78, 150, 78, 0.5);
+    --primary9Transparent: rgba(87, 168, 87, 0.5);
+    --primaryATransparent: rgba(95, 183, 95, 0.5);
+    --primaryBTransparent: rgba(104, 201, 104, 0.5);
+    --primaryCTransparent: rgba(114, 219, 114, 0.5);
+    --primaryDTransparent: rgba(121, 234, 121, 0.5);
+    --primaryETransparent: rgba(131, 252, 131, 0.5);
+
+    /* Accent Color: Teal (Hue 186) */
+    --accent1: #112121;
+    --accent2: #223232;
+    --accent3: #334343;
+    --accent4: #445454;
+    --accent5: #556565;
+    --accent6: #667676;
+    --accent7: #778787;
+    --accent8: #889898;
+    --accent9: #99a9a9;
+    --accentA: #aababa;
+    --accentB: #bbcbcb;
+    --accentC: #ccdcdc;
+    --accentD: #ddeded;
+    --accentE: #eefefe;
+
+    --accent1Muted: #112121;
+    --accent2Muted: #223232;
+    --accent3Muted: #334343;
+    --accent4Muted: #445454;
+    --accent5Muted: #556565;
+    --accent6Muted: #667676;
+    --accent7Muted: #778787;
+    --accent8Muted: #889898;
+    --accent9Muted: #99a9a9;
+    --accentAMuted: #aababa;
+    --accentBMuted: #bbcbcb;
+    --accentCMuted: #ccdcdc;
+    --accentDMuted: #ddeded;
+    --accentEMuted: #eefefe;
+
+    --accent1Transparent: rgba(17, 33, 33, 0.5);
+    --accent2Transparent: rgba(34, 50, 50, 0.5);
+    --accent3Transparent: rgba(51, 67, 67, 0.5);
+    --accent4Transparent: rgba(68, 84, 84, 0.5);
+    --accent5Transparent: rgba(85, 101, 101, 0.5);
+    --accent6Transparent: rgba(102, 118, 118, 0.5);
+    --accent7Transparent: rgba(119, 135, 135, 0.5);
+    --accent8Transparent: rgba(136, 152, 152, 0.5);
+    --accent9Transparent: rgba(153, 169, 169, 0.5);
+    --accentATransparent: rgba(170, 186, 186, 0.5);
+    --accentBTransparent: rgba(187, 203, 201, 0.5);
+    --accentCTransparent: rgba(204, 220, 220, 0.5);
+    --accentDTransparent: rgba(221, 237, 237, 0.5);
+    --accentETransparent: rgba(238, 254, 254, 0.5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #85B98D; /* Used for h3 */
+    --midPrimaryAccent8: #6B9773; /* Used for h3 small */
+    --midDefaultAccentA: #AAB2BA; /* Used for h5 */
+    --midDefaultAccent8: #889098; /* Used for h5 small */
+    --defaultAFullTransparent: rgba(170, 170, 186, 0); /* Used for row border groups */
+    --default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+
+    /* Global Bootstrap Colors */
+    /* Danger (Red) */
+    --danger1: #1E0000;
+    --danger2: #300000;
+    --danger3: #420000;
+    --danger4: #510000;
+    --danger5: #630000;
+    --danger6: #750000;
+    --danger7: #840000;
+    --danger8: #960000;
+    --danger9: #A80000;
+    --dangerA: #B70000;
+    --dangerB: #C90000;
+    --dangerC: #DB0000;
+    --dangerD: #EA0000;
+    --dangerE: #FC0000;
+
+    --danger1Muted: #211111;
+    --danger2Muted: #322222;
+    --danger3Muted: #433333;
+    --danger4Muted: #544444;
+    --danger5Muted: #655555;
+    --danger6Muted: #766666;
+    --danger7Muted: #877777;
+    --danger8Muted: #988888;
+    --danger9Auted: #a99999;
+    --dangerAMuted: #baaaaa;
+    --dangerBMuted: #cbbbbb;
+    --dangerCMuted: #dccccc;
+    --dangerDMuted: #eddddd;
+    --dangerEMuted: #feeeee;
+
+    --danger1Transparent: rgba(30, 0, 0, 0.5);
+    --danger2Transparent: rgba(48, 0, 0, 0.5);
+    --danger3Transparent: rgba(66, 0, 0, 0.5);
+    --danger4Transparent: rgba(81, 0, 0, 0.5);
+    --danger5Transparent: rgba(99, 0, 0, 0.5);
+    --danger6Transparent: rgba(117, 0, 0, 0.5);
+    --danger7Transparent: rgba(132, 0, 0, 0.5);
+    --danger8Transparent: rgba(150, 0, 0, 0.5);
+    --danger9Transparent: rgba(168, 0, 0, 0.5);
+    --dangerATransparent: rgba(183, 0, 0, 0.5);
+    --dangerBTransparent: rgba(201, 0, 0, 0.5);
+    --dangerCTransparent: rgba(219, 0, 0, 0.5);
+    --dangerDTransparent: rgba(234, 0, 0, 0.5);
+    --dangerETransparent: rgba(252, 0, 0, 0.5);
+
+    /* Warning (Yellow) */
+    --warning1: #1E1E00;
+    --warning2: #303000;
+    --warning3: #424200;
+    --warning4: #515100;
+    --warning5: #636300;
+    --warning6: #757500;
+    --warning7: #848400;
+    --warning8: #969600;
+    --warning9: #A8A800;
+    --warningA: #B7B700;
+    --warningB: #C9C900;
+    --warningC: #DBD800;
+    --warningD: #EAEA00;
+    --warningE: #FCFC00;
+
+    --warning1Muted: #212111;
+    --warning2Muted: #323222;
+    --warning3Muted: #434333;
+    --warning4Muted: #545444;
+    --warning5Muted: #656555;
+    --warning6Muted: #767666;
+    --warning7Muted: #878777;
+    --warning8Muted: #989888;
+    --warning9Auted: #a9a999;
+    --warningAMuted: #babaaa;
+    --warningBMuted: #cbcbbb;
+    --warningCMuted: #dcdccc;
+    --warningDMuted: #ededdd;
+    --warningEMuted: #fefeee;
+
+    --warning1Transparent: rgba(30, 30, 0, 0.5);
+    --warning2Transparent: rgba(48, 48, 0, 0.5);
+    --warning3Transparent: rgba(66, 66, 0, 0.5);
+    --warning4Transparent: rgba(81, 81, 0, 0.5);
+    --warning5Transparent: rgba(99, 99, 0, 0.5);
+    --warning6Transparent: rgba(117, 117, 0, 0.5);
+    --warning7Transparent: rgba(132, 132, 0, 0.5);
+    --warning8Transparent: rgba(150, 150, 0, 0.5);
+    --warning9Transparent: rgba(168, 168, 0, 0.5);
+    --warningATransparent: rgba(183, 183, 0, 0.5);
+    --warningBTransparent: rgba(201, 201, 0, 0.5);
+    --warningCTransparent: rgba(219, 219, 0, 0.5);
+    --warningDTransparent: rgba(234, 234, 0, 0.5);
+    --warningETransparent: rgba(252, 252, 0, 0.5);
+
+    /* Success (Green) */
+    --success1: #001E00;
+    --success2: #003000;
+    --success3: #004200;
+    --success4: #005100;
+    --success5: #006300;
+    --success6: #007500;
+    --success7: #008400;
+    --success8: #009600;
+    --success9: #00A800;
+    --successA: #00B700;
+    --successB: #00C900;
+    --successC: #00D800;
+    --successD: #00EA00;
+    --successE: #00FC00;
+
+    --success1Muted: #112111;
+    --success2Muted: #223222;
+    --success3Muted: #334333;
+    --success4Muted: #445444;
+    --success5Muted: #556555;
+    --success6Muted: #667666;
+    --success7Muted: #778777;
+    --success8Muted: #889888;
+    --success9Auted: #99a999;
+    --successAMuted: #aabaaa;
+    --successBMuted: #bbcbbb;
+    --successCMuted: #ccdccc;
+    --successDMuted: #ddeddd;
+    --successEMuted: #eefeee;
+
+    --success1Transparent: rgba(0, 30, 0, 0.5);
+    --success2Transparent: rgba(0, 48, 0, 0.5);
+    --success3Transparent: rgba(0, 66, 0, 0.5);
+    --success4Transparent: rgba(0, 81, 0, 0.5);
+    --success5Transparent: rgba(0, 99, 0, 0.5);
+    --success6Transparent: rgba(0, 117, 0, 0.5);
+    --success7Transparent: rgba(0, 132, 0, 0.5);
+    --success8Transparent: rgba(0, 150, 0, 0.5);
+    --success9Transparent: rgba(0, 168, 0, 0.5);
+    --successATransparent: rgba(0, 183, 0, 0.5);
+    --successBTransparent: rgba(0, 201, 0, 0.5);
+    --successCTransparent: rgba(0, 219, 0, 0.5);
+    --successDTransparent: rgba(0, 234, 0, 0.5);
+    --successETransparent: rgba(0, 252, 0, 0.5);
+
+    /* Info (Cyan) */
+    --info1: #001E1E;
+    --info2: #003030;
+    --info3: #004242;
+    --info4: #005151;
+    --info5: #006363;
+    --info6: #007575;
+    --info7: #008484;
+    --info8: #009696;
+    --info9: #00A8A8;
+    --infoA: #00B7B7;
+    --infoB: #00C9C9;
+    --infoC: #00D8D8;
+    --infoD: #00EAEA;
+    --infoE: #00FCFC;
+
+    --info1Muted: #112121;
+    --info2Muted: #223232;
+    --info3Muted: #334343;
+    --info4Muted: #445454;
+    --info5Muted: #556565;
+    --info6Muted: #667676;
+    --info7Muted: #778787;
+    --info8Muted: #889898;
+    --info9Auted: #99a9a9;
+    --infoAMuted: #aababa;
+    --infoBMuted: #bbcbcb;
+    --infoCMuted: #ccdcdc;
+    --infoDMuted: #ddeded;
+    --infoEMuted: #eefefe;
+
+    --info1Transparent: rgba(0, 30, 30, 0.5);
+    --info2Transparent: rgba(0, 48, 48, 0.5);
+    --info3Transparent: rgba(0, 66, 66, 0.5);
+    --info4Transparent: rgba(0, 81, 81, 0.5);
+    --info5Transparent: rgba(0, 99, 99, 0.5);
+    --info6Transparent: rgba(0, 117, 117, 0.5);
+    --info7Transparent: rgba(0, 132, 132, 0.5);
+    --info8Transparent: rgba(0, 150, 150, 0.5);
+    --info9Transparent: rgba(0, 168, 168, 0.5);
+    --infoATransparent: rgba(0, 183, 183, 0.5);
+    --infoBTransparent: rgba(0, 201, 201, 0.5);
+    --infoCTransparent: rgba(0, 219, 219, 0.5);
+    --infoDTransparent: rgba(0, 234, 234, 0.5);
+    --infoETransparent: rgba(0, 252, 252, 0.5);
+
+    /* Helper Variables */
+    --borderRadius: 5px;
+    --borderRadiusSmall: 2px;
+}
+
+/* Color Theme: Arshan */
+.user-css-presentation .arshan, .user-css-presentation .tag-theme-arshan, .user-css-presentation .category-3eabf245-4dc1-42bc-ac01-d1c4a7988d2e, .user-css-presentation .category-ddc22845-e8f3-401f-9c59-c9a390bf619e {
+    /* Default Color: Muted Blue (Hue 65) */
+    --default1: #111111;
+    --default2: #222222;
+    --default3: #333333;
+    --default4: #444444;
+    --default5: #555555;
+    --default6: #666666;
+    --default7: #777777;
+    --default8: #888888;
+    --default9: #999999;
+    --defaultA: #AAAAAA;
+    --defaultB: #BBBBBB;
+    --defaultC: #CCCCCC;
+    --defaultD: #DDDDDD;
+    --defaultE: #EEEEEE;
+
+    --default1Muted: #111111;
+    --default2Muted: #222222;
+    --default3Muted: #333333;
+    --default4Muted: #444444;
+    --default5Muted: #555555;
+    --default6Muted: #666666;
+    --default7Muted: #777777;
+    --default8Muted: #888888;
+    --default9Muted: #999999;
+    --defaultAMuted: #AAAAAA;
+    --defaultBMuted: #BBBBBB;
+    --defaultCMuted: #CCCCCC;
+    --defaultDMuted: #DDDDDD;
+    --defaultEMuted: #EEEEEE;
+
+    --default1Transparent: rgba(17, 17, 17, 0.5);
+    --default2Transparent: rgba(34, 34, 34, 0.5);
+    --default3Transparent: rgba(51, 51, 51, 0.5);
+    --default4Transparent: rgba(68, 68, 68, 0.5);
+    --default5Transparent: rgba(85, 85, 85, 0.5);
+    --default6Transparent: rgba(102, 102, 102, 0.5);
+    --default7Transparent: rgba(119, 119, 119, 0.5);
+    --default8Transparent: rgba(136, 136, 136, 0.5);
+    --default9Transparent: rgba(153, 153, 153, 0.5);
+    --defaultATransparent: rgba(170, 170, 170, 0.5);
+    --defaultBTransparent: rgba(187, 187, 187, 0.5);
+    --defaultCTransparent: rgba(204, 204, 204, 0.5);
+    --defaultDTransparent: rgba(221, 221, 221, 0.5);
+    --defaultETransparent: rgba(238, 238, 238, 0.5);
+
+    /* Primary Color: Red-Orange (Hue 10, Sat 100) */
+    --primary1: #1E0C00;
+    --primary2: #2D1300;
+    --primary3: #3F1800;
+    --primary4: #4F1E00;
+    --primary5: #602600;
+    --primary6: #722B00;
+    --primary7: #822D00;
+    --primary8: #933B00;
+    --primary9: #A54200;
+    --primaryA: #B54800;
+    --primaryB: #C64500;
+    --primaryC: #D85D00;
+    --primaryD: #E86000;
+    --primaryE: #F95F00;
+
+    --primary1Muted: #1E150F;
+    --primary2Muted: #302720;
+    --primary3Muted: #423933;
+    --primary4Muted: #514842;
+    --primary5Muted: #635A54;
+    --primary6Muted: #756C66;
+    --primary7Muted: #847B76;
+    --primary8Muted: #968D87;
+    --primary9Muted: #A89F99;
+    --primaryAMuted: #B7AEA8;
+    --primaryBMuted: #C9C0BB;
+    --primaryCMuted: #DBD2CB;
+    --primaryDMuted: #EAE2DC;
+    --primaryEMuted: #FCF3ED;
+
+    --primary1Transparent: rgba(30, 12, 0, 0.5);
+    --primary2Transparent: rgba(45, 19, 0, 0.5);
+    --primary3Transparent: rgba(63, 24, 0, 0.5);
+    --primary4Transparent: rgba(79, 30, 0, 0.5);
+    --primary5Transparent: rgba(96, 38, 0, 0.5);
+    --primary6Transparent: rgba(114, 43, 0, 0.5);
+    --primary7Transparent: rgba(130, 45, 0, 0.5);
+    --primary8Transparent: rgba(147, 59, 0, 0.5);
+    --primary9Transparent: rgba(165, 66, 0, 0.5);
+    --primaryATransparent: rgba(181, 72, 0, 0.5);
+    --primaryBTransparent: rgba(198, 69, 0, 0.5);
+    --primaryCTransparent: rgba(216, 93, 0, 0.5);
+    --primaryDTransparent: rgba(232, 96, 0, 0.5);
+    --primaryETransparent: rgba(249, 95, 0, 0.5);
+
+    /* Accent Color: Teal (Hue 186) */
+    --accent1: #1E150F;
+    --accent2: #302720;
+    --accent3: #423933;
+    --accent4: #514842;
+    --accent5: #635A54;
+    --accent6: #756C66;
+    --accent7: #847B76;
+    --accent8: #968D87;
+    --accent9: #A89F99;
+    --accentA: #B7AEA8;
+    --accentB: #C9C0BB;
+    --accentC: #DBD2CB;
+    --accentD: #EAE2DC;
+    --accentE: #FCF3ED;
+
+    --accent1Muted: #1E150F;
+    --accent2Muted: #302720;
+    --accent3Muted: #423933;
+    --accent4Muted: #514842;
+    --accent5Muted: #635A54;
+    --accent6Muted: #756C66;
+    --accent7Muted: #847B76;
+    --accent8Muted: #968D87;
+    --accent9Muted: #A89F99;
+    --accentAMuted: #B7AEA8;
+    --accentBMuted: #C9C0BB;
+    --accentCMuted: #DBD2CB;
+    --accentDMuted: #EAE2DC;
+    --accentEMuted: #FCF3ED;
+
+    --accent1Transparent: rgba(30, 21, 15, 0.5);
+    --accent2Transparent: rgba(40, 39, 32, 0.5);
+    --accent3Transparent: rgba(66, 57, 51, 0.5);
+    --accent4Transparent: rgba(81, 72, 66, 0.5);
+    --accent5Transparent: rgba(99, 90, 84, 0.5);
+    --accent6Transparent: rgba(117, 108, 102, 0.5);
+    --accent7Transparent: rgba(132, 123, 118, 0.5);
+    --accent8Transparent: rgba(150, 141, 135, 0.5);
+    --accent9Transparent: rgba(168, 159, 153, 0.5);
+    --accentATransparent: rgba(183, 174, 168, 0.5);
+    --accentBTransparent: rgba(201, 192, 187, 0.5);
+    --accentCTransparent: rgba(219, 210, 203, 0.5);
+    --accentDTransparent: rgba(234, 226, 220, 0.5);
+    --accentETransparent: rgba(252, 243, 237, 0.5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #C98456; /* Used for h3 */
+    --midPrimaryAccent8: #966544; /* Used for h3 small */
+    --midDefaultAccentA: #C9C0BA; /* Used for h5 */
+    --midDefaultAccent8: #96928F; /* Used for h5 small */
+    --defaultAFullTransparent: rgba(170, 170, 186, 0); /* Used for row border groups */
+    --default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+}
+
+/* Color Theme: Drakari */
+.user-css-presentation .drakari, .user-css-presentation .tag-theme-drakari, .user-css-presentation .category-ea4be012-9100-4767-85ab-be1e9f3ad706, .user-css-presentation .category-3bf6bdc2-817f-4056-be26-e358879cdc5d {
+    /* Default Color: Muted rED (Hue 0) */
+    --default1: #211111;
+    --default2: #322222;
+    --default3: #433333;
+    --default4: #544444;
+    --default5: #655555;
+    --default6: #766666;
+    --default7: #877777;
+    --default8: #988888;
+    --default9: #A99999;
+    --defaultA: #BAAAAA;
+    --defaultB: #CBBBBB;
+    --defaultC: #DCCCCC;
+    --defaultD: #EDDDDD;
+    --defaultE: #FEEEEE;
+
+    --default1Muted: #211111;
+    --default2Muted: #322222;
+    --default3Muted: #433333;
+    --default4Muted: #544444;
+    --default5Muted: #655555;
+    --default6Muted: #766666;
+    --default7Muted: #877777;
+    --default8Muted: #988888;
+    --default9Muted: #A99999;
+    --defaultAMuted: #BAAAAA;
+    --defaultBMuted: #CBBBBB;
+    --defaultCMuted: #DCCCCC;
+    --defaultDMuted: #EDDDDD;
+    --defaultEMuted: #FEEEEE;
+
+    --default1Transparent: rgba(33, 17, 17, 0.5);
+    --default2Transparent: rgba(50, 34, 34, 0.5);
+    --default3Transparent: rgba(67, 51, 51, 0.5);
+    --default4Transparent: rgba(84, 68, 68, 0.5);
+    --default5Transparent: rgba(101, 85, 85, 0.5);
+    --default6Transparent: rgba(118, 102, 102, 0.5);
+    --default7Transparent: rgba(135, 119, 119, 0.5);
+    --default8Transparent: rgba(152, 136, 136, 0.5);
+    --default9Transparent: rgba(169, 153, 153, 0.5);
+    --defaultATransparent: rgba(186, 170, 170, 0.5);
+    --defaultBTransparent: rgba(203, 187, 187, 0.5);
+    --defaultCTransparent: rgba(220, 204, 204, 0.5);
+    --defaultDTransparent: rgba(237, 221, 221, 0.5);
+    --defaultETransparent: rgba(254, 238, 238, 0.5);
+
+    /* Primary Color: Purple->Yellow */
+    --primary1: #1A031C;
+    --primary2: #2B052D;
+    --primary3: #3F0A36;
+    --primary4: #4F0F3B;
+    --primary5: #60173D;
+    --primary6: #721E3F;
+    --primary7: #82293C;
+    --primary8: #93353D;
+    --primary9: #A54F45;
+    --primaryA: #B5674D;
+    --primaryB: #C68A5F;
+    --primaryC: #D8AD70;
+    --primaryD: #E8CE81;
+    --primaryE: #F9EF95;
+
+    --primary1Muted: #1C0E1C;
+    --primary2Muted: #2D212B;
+    --primary3Muted: #3F313C;
+    --primary4Muted: #4F4149;
+    --primary5Muted: #605358;
+    --primary6Muted: #726468;
+    --primary7Muted: #827376;
+    --primary8Muted: #938586;
+    --primary9Muted: #A59998;
+    --primaryAMuted: #B5ABA8;
+    --primaryBMuted: #C6BFBA;
+    --primaryCMuted: #D8D3CD;
+    --primaryDMuted: #E8E5DC;
+    --primaryEMuted: #F9F8EF;
+
+    --primary1Transparent: rgba(36, 3, 28, 0.5);
+    --primary2Transparent: rgba(43, 5, 45, 0.5);
+    --primary3Transparent: rgba(63, 10, 54, 0.5);
+    --primary4Transparent: rgba(79, 15, 59, 0.5);
+    --primary5Transparent: rgba(96, 23, 61, 0.5);
+    --primary6Transparent: rgba(114, 30, 61, 0.5);
+    --primary7Transparent: rgba(130, 41, 60, 0.5);
+    --primary8Transparent: rgba(147, 53, 61, 0.5);
+    --primary9Transparent: rgba(165, 79, 69, 0.5);
+    --primaryATransparent: rgba(181, 103, 77, 0.5);
+    --primaryBTransparent: rgba(198, 138, 95, 0.5);
+    --primaryCTransparent: rgba(216, 173, 112, 0.5);
+    --primaryDTransparent: rgba(232, 206, 129, 0.5);
+    --primaryETransparent: rgba(249, 239, 149, 0.5);
+
+    /* Accent Color: Purple->Yellow */
+    --accent1: #1C0110;
+    --accent2: #2D011A;
+    --accent3: #3F0A1C;
+    --accent4: #4F0E21;
+    --accent5: #601824;
+    --accent6: #722527;
+    --accent7: #823B34;
+    --accent8: #935945;
+    --accent9: #A5765B;
+    --accentA: #B59572;
+    --accentB: #C6B08B;
+    --accentC: #D8CDA9;
+    --accentD: #E8E2C7;
+    --accentE: #F9F9E8;
+
+    --accent1Muted: #1C0D17;
+    --accent2Muted: #2D2127;
+    --accent3Muted: #3F3538;
+    --accent4Muted: #4F4446;
+    --accent5Muted: #605859;
+    --accent6Muted: #726868;
+    --accent7Muted: #827977;
+    --accent8Muted: #938A88;
+    --accent9Muted: #A59D9A;
+    --accentAMuted: #B5AEA8;
+    --accentBMuted: #C6C1BA;
+    --accentCMuted: #D8D6CD;
+    --accentDMuted: #E8E6DC;
+    --accentEMuted: #F9F9ED;
+
+    --accent1Transparent: rgba(28, 1, 16, 0.5);
+    --accent2Transparent: rgba(45, 1, 26, 0.5);
+    --accent3Transparent: rgba(63, 10, 28, 0.5);
+    --accent4Transparent: rgba(79, 14, 33, 0.5);
+    --accent5Transparent: rgba(96, 24, 36, 0.5);
+    --accent6Transparent: rgba(114, 37, 39, 0.5);
+    --accent7Transparent: rgba(130, 59, 52, 0.5);
+    --accent8Transparent: rgba(147, 89, 69, 0.5);
+    --accent9Transparent: rgba(165, 118, 91, 0.5);
+    --accentATransparent: rgba(181, 149, 114, 0.5);
+    --accentBTransparent: rgba(198, 176, 139, 0.5);
+    --accentCTransparent: rgba(216, 205, 169, 0.5);
+    --accentDTransparent: rgba(232, 223, 199, 0.5);
+    --accentETransparent: rgba(249, 249, 232, 0.5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #B57E60; /* Used for h3 */
+    --midPrimaryAccent8: #934741; /* Used for h3 small */
+    --midDefaultAccentA: #B8A08E; /* Used for h5 */
+    --midDefaultAccent8: #967167; /* Used for h5 small */
+    --defaultAFullTransparent: rgba(186, 170, 170, 0); /* Used for row border groups */
+    --default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+}
+
+/* Color Theme: Solus */
+.user-css-presentation .solus, .user-css-presentation .tag-theme-solus, .user-css-presentation .category-1eb3624c-9c1c-4c81-aaa2-144280de91b0, .user-css-presentation .category-66c5e6cd-d242-4156-aed4-18f0a3183e2f {
+    /* Default Color: Muted Blue-Green */
+    --default1: #0F191E;
+    --default2: #202B30;
+    --default3: #333D42;
+    --default4: #424C51;
+    --default5: #545E63;
+    --default6: #667075;
+    --default7: #767F84;
+    --default8: #879196;
+    --default9: #99A3A8;
+    --defaultA: #A8B2B7;
+    --defaultB: #BBC4C9;
+    --defaultC: #CBD6DB;
+    --defaultD: #DCE5EA;
+    --defaultE: #EDF7FC;
+
+    --default1Muted: #0F191E;
+    --default2Muted: #202B30;
+    --default3Muted: #333D42;
+    --default4Muted: #424C51;
+    --default5Muted: #545E63;
+    --default6Muted: #667075;
+    --default7Muted: #767F84;
+    --default8Muted: #879196;
+    --default9Muted: #99A3A8;
+    --defaultAMuted: #A8B2B7;
+    --defaultBMuted: #BBC4C9;
+    --defaultCMuted: #CBD6DB;
+    --defaultDMuted: #DCE5EA;
+    --defaultEMuted: #EDF7FC;
+
+    --default1Transparent: rgba(15, 25, 30, 0.5);
+    --default2Transparent: rgba(32, 43, 48, 0.5);
+    --default3Transparent: rgba(51, 61, 66, 0.5);
+    --default4Transparent: rgba(66, 76, 81, 0.5);
+    --default5Transparent: rgba(84, 94, 99, 0.5);
+    --default6Transparent: rgba(102, 112, 117, 0.5);
+    --default7Transparent: rgba(118, 127, 132, 0.5);
+    --default8Transparent: rgba(135, 145, 150, 0.5);
+    --default9Transparent: rgba(153, 163, 168, 0.5);
+    --defaultATransparent: rgba(168, 178, 183, 0.5);
+    --defaultBTransparent: rgba(187, 196, 201, 0.5);
+    --defaultCTransparent: rgba(203, 214, 219, 0.5);
+    --defaultDTransparent: rgba(220, 229, 234, 0.5);
+    --defaultETransparent: rgba(237, 247, 252, 0.5);
+
+    /* Primary Color: Yellow */
+    --primary1: #1E0800;
+    --primary2: #300C00;
+    --primary3: #421600;
+    --primary4: #512101;
+    --primary5: #632D01;
+    --primary6: #753E03;
+    --primary7: #844F05;
+    --primary8: #966306;
+    --primary9: #A87A08;
+    --primaryA: #B7920B;
+    --primaryB: #C9AD0C;
+    --primaryC: #DBCA0F;
+    --primaryD: #EAEA10;
+    --primaryE: #FCFC11;
+
+    --primary1Muted: #1C120E;
+    --primary2Muted: #2D221F;
+    --primary3Muted: #3F3531;
+    --primary4Muted: #4F4640;
+    --primary5Muted: #605852;
+    --primary6Muted: #726B63;
+    --primary7Muted: #827B73;
+    --primary8Muted: #938E85;
+    --primary9Muted: #A5A196;
+    --primaryAMuted: #B5B1A6;
+    --primaryBMuted: #C6C4B8;
+    --primaryCMuted: #D8D7C9;
+    --primaryDMuted: #E8E8DA;
+    --primaryEMuted: #F9F9EA;
+
+    --primary1Transparent: rgba(30, 8, 0, 0.5);
+    --primary2Transparent: rgba(48, 12, 0, 0.5);
+    --primary3Transparent: rgba(66, 22, 0, 0.5);
+    --primary4Transparent: rgba(81, 33, 1, 0.5);
+    --primary5Transparent: rgba(99, 45, 1, 0.5);
+    --primary6Transparent: rgba(117, 62, 3, 0.5);
+    --primary7Transparent: rgba(132, 79, 5, 0.5);
+    --primary8Transparent: rgba(150, 99, 6, 0.5);
+    --primary9Transparent: rgba(168, 122, 8, 0.5);
+    --primaryATransparent: rgba(183, 146, 11, 0.5);
+    --primaryBTransparent: rgba(207, 173, 12, 0.5);
+    --primaryCTransparent: rgba(219, 202, 15, 0.5);
+    --primaryDTransparent: rgba(234, 234, 16, 0.5);
+    --primaryETransparent: rgba(252, 252, 17, 0.5);
+
+    /* Accent Color: Muted Green */
+    --accent1: #141E0F;
+    --accent2: #263020;
+    --accent3: #384233;
+    --accent4: #475142;
+    --accent5: #596354;
+    --accent6: #6B7566;
+    --accent7: #7A8476;
+    --accent8: #8C9687;
+    --accent9: #9EA899;
+    --accentA: #ADB7A8;
+    --accentB: #C0C9BB;
+    --accentC: #D1DBCB;
+    --accentD: #E1EADC;
+    --accentE: #F2FCED;
+
+    --accent1Muted: #141E0F;
+    --accent2Muted: #263020;
+    --accent3Muted: #384233;
+    --accent4Muted: #475142;
+    --accent5Muted: #596354;
+    --accent6Muted: #6B7566;
+    --accent7Muted: #7A8476;
+    --accent8Muted: #8C9687;
+    --accent9Muted: #9EA899;
+    --accentAMuted: #ADB7A8;
+    --accentBMuted: #C0C9BB;
+    --accentCMuted: #D1DBCB;
+    --accentDMuted: #E1EADC;
+    --accentEMuted: #F2FCED;
+
+    --accent1Transparent: rgba(20, 30, 15, 0.5);
+    --accent2Transparent: rgba(38, 48, 32, 0.5);
+    --accent3Transparent: rgba(56, 66, 51, 0.5);
+    --accent4Transparent: rgba(71, 81, 66, 0.5);
+    --accent5Transparent: rgba(89, 99, 84, 0.5);
+    --accent6Transparent: rgba(107, 117, 102, 0.5);
+    --accent7Transparent: rgba(122, 132, 118, 0.5);
+    --accent8Transparent: rgba(140, 150, 135, 0.5);
+    --accent9Transparent: rgba(158, 168, 153, 0.5);
+    --accentATransparent: rgba(173, 183, 168, 0.5);
+    --accentBTransparent: rgba(192, 201, 187, 0.5);
+    --accentCTransparent: rgba(209, 219, 203, 0.5);
+    --accentDTransparent: rgba(225, 235, 220, 0.5);
+    --accentETransparent: rgba(242, 252, 237, 0.5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #B2A55A; /* Used for h3 */
+    --midPrimaryAccent8: #917D47; /* Used for h3 small */
+    --midDefaultAccentA: #ABB5B0; /* Used for h5 */
+    --midDefaultAccent8: #8A948F; /* Used for h5 small */
+    --defaultAFullTransparent: rgba(186, 170, 170, 0); /* Used for row border groups */
+    --default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+}
+
+/* Color Theme: Terran */
+.user-css-presentation .terran, .user-css-presentation .tag-theme-terran, .user-css-presentation .category-f680cb8b-4874-4152-806a-35d2b42c6c0b, .user-css-presentation .category-5162d4c3-0773-4b70-b1aa-dc2d9d495d27 {
+    /* Default Color: Green-Yellow */
+    --default1: #151C07;
+    --default2: #232E0D;
+    --default3: #303F13;
+    --default4: #3E5017;
+    --default5: #4C601A;
+    --default6: #5C711D;
+    --default7: #6C8220;
+    --default8: #839523;
+    --default9: #99A826;
+    --defaultA: #ACB727;
+    --defaultB: #BEC627;
+    --defaultC: #CED72B;
+    --defaultD: #DEE82E;
+    --defaultE: #EBF430;
+
+    --default1Muted: #15190C;
+    --default2Muted: #292D1E;
+    --default3Muted: #383D2F;
+    --default4Muted: #4A4F40;
+    --default5Muted: #5A5E50;
+    --default6Muted: #6C7062;
+    --default7Muted: #7C7F72;
+    --default8Muted: #919385;
+    --default9Muted: #A4A598;
+    --defaultAMuted: #B4B5A6;
+    --defaultBMuted: #C3C4B8;
+    --defaultCMuted: #D5D6C7;
+    --defaultDMuted: #E4E5DA;
+    --defaultEMuted: #F1F2E6;
+
+    --default1Transparent: rgba(21, 28, 7, 0.5);
+    --default2Transparent: rgba(35, 46, 13, 0.5);
+    --default3Transparent: rgba(48, 63, 19, 0.5);
+    --default4Transparent: rgba(62, 80, 23, 0.5);
+    --default5Transparent: rgba(76, 96, 26, 0.5);
+    --default6Transparent: rgba(92, 113, 29, 0.5);
+    --default7Transparent: rgba(108, 130, 32, 0.5);
+    --default8Transparent: rgba(131, 149, 35, 0.5);
+    --default9Transparent: rgba(153, 168, 38, 0.5);
+    --defaultATransparent: rgba(172, 183, 39, 0.5);
+    --defaultBTransparent: rgba(190, 198, 39, 0.5);
+    --defaultCTransparent: rgba(206, 215, 43, 0.5);
+    --defaultDTransparent: rgba(222, 232, 46, 0.5);
+    --defaultETransparent: rgba(235, 244, 48, 0.5);
+
+    /* Primary Color: Cyan */
+    --primary1: #020819;
+    --primary2: #05132B;
+    --primary3: #081D3D;
+    --primary4: #0E2C4E;
+    --primary5: #133B5E;
+    --primary6: #1B4E6F;
+    --primary7: #22607F;
+    --primary8: #2C7992;
+    --primary9: #3691A5;
+    --primaryA: #41A8B5;
+    --primaryB: #4CBEC4;
+    --primaryC: #5AD2CF;
+    --primaryD: #67E5DA;
+    --primaryE: #6DF2E9;
+
+    --primary1Muted: #0B0E16;
+    --primary2Muted: #1B2028;
+    --primary3Muted: #2D323A;
+    --primary4Muted: #3E454C;
+    --primary5Muted: #4E555B;
+    --primary6Muted: #60686D;
+    --primary7Muted: #70787C;
+    --primary8Muted: #848E91;
+    --primary9Muted: #97A1A3;
+    --primaryAMuted: #A4B1B2;
+    --primaryBMuted: #B6C1C1;
+    --primaryCMuted: #C2D1D0;
+    --primaryDMuted: #D9E2E2;
+    --primaryEMuted: #E6EFEE;
+
+    --primary1Transparent: rgba(2, 8, 25, 0.5);
+    --primary2Transparent: rgba(5, 19, 49, 0.5);
+    --primary3Transparent: rgba(8, 29, 61, 0.5);
+    --primary4Transparent: rgba(14, 44, 78, 0.5);
+    --primary5Transparent: rgba(19, 59, 94, 0.5);
+    --primary6Transparent: rgba(27, 78, 111, 0.5);
+    --primary7Transparent: rgba(34, 96, 127, 0.5);
+    --primary8Transparent: rgba(44, 121, 146, 0.5);
+    --primary9Transparent: rgba(54, 145, 165, 0.5);
+    --primaryATransparent: rgba(65, 168, 181, 0.5);
+    --primaryBTransparent: rgba(76, 190, 196, 0.5);
+    --primaryCTransparent: rgba(91, 210, 207, 0.5);
+    --primaryDTransparent: rgba(103, 229, 218, 0.5);
+    --primaryETransparent: rgba(109, 242, 233, 0.5);
+
+    /* Accent Color: Moss Green */
+    --accent1: #041910;
+    --accent2: #0A2B17;
+    --accent3: #103D1E;
+    --accent4: #194C21;
+    --accent5: #225B23;
+    --accent6: #336C2E;
+    --accent7: #447C39;
+    --accent8: #5F904A;
+    --accent9: #79A35B;
+    --accentA: #92B26D;
+    --accentB: #AAC17F;
+    --accentC: #C2D383;
+    --accentD: #DAE587;
+    --accentE: #ECF4BA;
+
+    --accent1Muted: #0B1611;
+    --accent2Muted: #1B2820;
+    --accent3Muted: #2D3A31;
+    --accent4Muted: #3C493E;
+    --accent5Muted: #4C594C;
+    --accent6Muted: #606B5F;
+    --accent7Muted: #717A6F;
+    --accent8Muted: #858E81;
+    --accent9Muted: #9AA095;
+    --accentAMuted: #AAAFA3;
+    --accentBMuted: #BCBFB5;
+    --accentCMuted: #D2D6C7;
+    --accentDMuted: #ECEDE6;
+    --accentEMuted: #F1F2EA;
+
+    --accent1Transparent: rgba(4, 25, 16, 0.5);
+    --accent2Transparent: rgba(10, 43, 23, 0.5);
+    --accent3Transparent: rgba(16, 61, 30, 0.5);
+    --accent4Transparent: rgba(25, 76, 33, 0.5);
+    --accent5Transparent: rgba(34, 91, 35, 0.5);
+    --accent6Transparent: rgba(51, 108, 46, 0.5);
+    --accent7Transparent: rgba(64, 124, 57, 0.5);
+    --accent8Transparent: rgba(95, 144, 74, 0.5);
+    --accent9Transparent: rgba(121, 163, 91, 0.5);
+    --accentATransparent: rgba(146, 178, 109, 0.5);
+    --accentBTransparent: rgba(170, 193, 127, 0.5);
+    --accentCTransparent: rgba(194, 211, 131, 0.5);
+    --accentDTransparent: rgba(218, 229, 135, 0.5);
+    --accentETransparent: rgba(236, 244, 186, 0.5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #6AAD91; /* Used for h3 */
+    --midPrimaryAccent8: #46856E; /* Used for h3 small */
+    --midDefaultAccentA: #9FB54A; /* Used for h5 */
+    --midDefaultAccent8: #719337; /* Used for h5 small */
+    --defaultAFullTransparent: rgba(172, 183, 39, 0); /* Used for row border groups */
+    --default3MutedTransparent: rgba(56, 61, 47, 0.5); /* Used for body background */
+}
+
+.user-css-presentation .sionian, .user-css-presentation .tag-theme-sionian, .user-css-presentation .category-723c6440-ca73-4e61-b35c-9d66dd1a27d0, .user-css-presentation .category-264de840-9175-4c60-935f-ff5ce2eeb023 {
+    /* Default Color: Muted Tan */
+    --default1: #1E0F01;
+    --default2: #302011;
+    --default3: #423323;
+    --default4: #514232;
+    --default5: #635445;
+    --default6: #756656;
+    --default7: #847667;
+    --default8: #968778;
+    --default9: #A8998A;
+    --defaultA: #B7A89A;
+    --defaultB: #C9BBAD;
+    --defaultC: #DBCBBC;
+    --defaultD: #EADCCE;
+    --defaultE: #FCEDDE;
+
+    --default1Muted: #1E0F01;
+    --default2Muted: #302011;
+    --default3Muted: #423323;
+    --default4Muted: #514232;
+    --default5Muted: #635445;
+    --default6Muted: #756656;
+    --default7Muted: #847667;
+    --default8Muted: #968778;
+    --default9Muted: #A8998A;
+    --defaultAMuted: #B7A89A;
+    --defaultBMuted: #C9BBAD;
+    --defaultCMuted: #DBCBBC;
+    --defaultDMuted: #EADCCE;
+    --defaultEMuted: #FCEDDE;
+
+    --default1Transparent: rgba(30, 15, 1, 0.5);
+    --default2Transparent: rgba(48, 32, 17, 0.5);
+    --default3Transparent: rgba(66, 51, 35, 0.5);
+    --default4Transparent: rgba(81, 66, 50, 0.5);
+    --default5Transparent: rgba(99, 84, 69, 0.5);
+    --default6Transparent: rgba(117, 112, 86, 0.5);
+    --default7Transparent: rgba(132, 118, 103, 0.5);
+    --default8Transparent: rgba(150, 133, 120, 0.5);
+    --default9Transparent: rgba(168, 153, 138, 0.5);
+    --defaultATransparent: rgba(183, 168, 154, 0.5);
+    --defaultBTransparent: rgba(201, 187, 173, 0.5);
+    --defaultCTransparent: rgba(219, 203, 188, 0.5);
+    --defaultDTransparent: rgba(234, 220, 206, 0.5);
+    --defaultETransparent: rgba(252, 237, 222, 0.5);
+
+    /* Primary Color: Green */
+    --primary1: #071902;
+    --primary2: #0D2B07;
+    --primary3: #123D0B;
+    --primary4: #1A4E14;
+    --primary5: #215E1C;
+    --primary6: #2B6F28;
+    --primary7: #347F34;
+    --primary8: #449147;
+    --primary9: #53A359;
+    --primaryA: #67B46F;
+    --primaryB: #7BC484;
+    --primaryC: #91D59C;
+    --primaryD: #A7E5B3;
+    --primaryE: #B4F7C1;
+
+    --primary1Muted: #0E160B;
+    --primary2Muted: #1F281E;
+    --primary3Muted: #2F3A2D;
+    --primary4Muted: #434C42;
+    --primary5Muted: #505B4F;
+    --primary6Muted: #616D60;
+    --primary7Muted: #6F7C6F;
+    --primary8Muted: #818E82;
+    --primary9Muted: #95A096;
+    --primaryAMuted: #A6B2A7;
+    --primaryBMuted: #B6C1B7;
+    --primaryCMuted: #C9D3CA;
+    --primaryDMuted: #D7E2D9;
+    --primaryEMuted: #EBF4EC;
+
+    --primary1Transparent: rgba(7, 25, 2, 0.5);
+    --primary2Transparent: rgba(13, 43, 7, 0.5);
+    --primary3Transparent: rgba(18, 61, 11, 0.5);
+    --primary4Transparent: rgba(26, 78, 20, 0.5);
+    --primary5Transparent: rgba(33, 94, 28, 0.5);
+    --primary6Transparent: rgba(43, 111, 40, 0.5);
+    --primary7Transparent: rgba(52, 127, 52, 0.5);
+    --primary8Transparent: rgba(68, 145, 71, 0.5);
+    --primary9Transparent: rgba(83, 163, 89, 0.5);
+    --primaryATransparent: rgba(103, 180, 111, 0.5);
+    --primaryBTransparent: rgba(123, 196, 132, 0.5);
+    --primaryCTransparent: rgba(145, 213, 156, 0.5);
+    --primaryDTransparent: rgba(167, 229, 179, 0.5);
+    --primaryETransparent: rgba(180, 247, 193, 0.5);
+
+    /* Accent Color: Orange */
+    --accent1: #160A00;
+    --accent2: #281502;
+    --accent3: #3A1F04;
+    --accent4: #4B2C09;
+    --accent5: #5B390D;
+    --accent6: #6C4913;
+    --accent7: #7C5818;
+    --accent8: #8E6920;
+    --accent9: #A07A28;
+    --accentA: #B18D31;
+    --accentB: #C19F3A;
+    --accentC: #D2B546;
+    --accentD: #E2CA51;
+    --accentE: #F4DA58;
+
+    --accent1Muted: #140E0A;
+    --accent2Muted: #26211C;
+    --accent3Muted: #38312B;
+    --accent4Muted: #494540;
+    --accent5Muted: #59544D;
+    --accent6Muted: #6B665F;
+    --accent7Muted: #7A756E;
+    --accent8Muted: #8C877F;
+    --accent9Muted: #9E9B94;
+    --accentAMuted: #AFACA5;
+    --accentBMuted: #BFBCB5;
+    --accentCMuted: #D1CFC8;
+    --accentDMuted: #E0DED7;
+    --accentEMuted: #F2F0EA;
+
+    --accent1Transparent: rgba(22, 10, 0, 0.5);
+    --accent2Transparent: rgba(40, 21, 2, 0.5);
+    --accent3Transparent: rgba(58, 31, 4, 0.5);
+    --accent4Transparent: rgba(75, 44, 9, 0.5);
+    --accent5Transparent: rgba(91, 57, 13, 0.5);
+    --accent6Transparent: rgba(108, 73, 19, 0.5);
+    --accent7Transparent: rgba(124, 88, 24, 0.5);
+    --accent8Transparent: rgba(142, 105, 32, 0.5);
+    --accent9Transparent: rgba(160, 122, 40, 0.5);
+    --accentATransparent: rgba(177, 141, 49, 0.5);
+    --accentBTransparent: rgba(193, 159, 58, 0.5);
+    --accentCTransparent: rgba(210, 181, 70, 0.5);
+    --accentDTransparent: rgba(226, 202, 81, 0.5);
+    --accentETransparent: rgba(244, 218, 88, 0.5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #8CA150; /* Used for h3 */
+    --midPrimaryAccent8: #697D34; /* Used for h3 small */
+    --midDefaultAccentA: #B49B66; /* Used for h5 */
+    --midDefaultAccent8: #92784C; /* Used for h5 small */
+    --defaultAFullTransparent: rgba(172, 183, 39, 0); /* Used for row border groups */
+    --default3MutedTransparent: rgba(66, 51, 35, 0.5); /* Used for body background */
+}
 
 /* FONTS */
 @font-face {
@@ -21,27 +1103,28 @@
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
-/* REMOVE BACKGROUND */
-#full-layout div.user-css-viewer {
-    background: none;
+/* LAYOUT - MAIN */
+.user-css-presentation {
+    font-size: 1.6rem;
 }
 
-/* LAYOUT - MAIN */
-.user-css-presentation .page, .user-css-presentation .worldmenu-inner {
-    background-image: none;
-    font-family: IBM Plex Sans Condensed, sans-serif;
+.user-css-presentation .page,
+.user-css-presentation .worldmenu-inner {
+    background: none;
     border: none;
-    border-radius: 5px;
+    border-radius: var(--borderRadius);
+    font-family: IBM Plex Sans Condensed, sans-serif;
+    margin-bottom: 3rem;
+    margin-top: 0;
+    padding-bottom: 2rem;
+    padding-left: 25px;
+    padding-right: 25px;
 }
 
 /* LAYOUT - HTML */
-.user-css-presentation a, .user-css-presentation a:focus {
+.user-css-presentation a,
+.user-css-presentation a:focus {
     font-weight: bold;
-}
-
-/* I don't know why this is needed but apparently I broke article-panel and need to do this to fix it */
-.user-css-presentation .article-panel a {
-    display: inline-block;
 }
 
 .user-css-presentation b {
@@ -49,86 +1132,95 @@
 }
 
 .user-css-presentation blockquote {
-    border-radius: 4px;
     border-left: 10px solid;
-    font-family: IBM Plex Sans Condensed, sans-serif;
-    font-size: 16px;
+    border-radius: var(--borderRadius);
+    font-family: inherit;
+    font-size: 1.6rem;
+    padding: 20px;
+    line-height: 1.5em;
+    margin: 10px;
 }
 
 .user-css-presentation blockquote .author {
-    font-size: 16px;
+    font-family: inherit;
+    font-size: 1.4rem;
+    padding-right: 10px;
 }
 
-.user-css-presentation code, .user-css-presentation pre {
+.user-css-presentation code,
+.user-css-presentation pre {
     border: none;
-    border-radius: 2px;
+    border-radius: var(--borderRadiusSmall);
 }
 
-.user-css-presentation .panel dl {
-    margin-bottom: 0;
-}
-
-.user-css-presentation h1, .user-css-presentation h1 a {
-    font-size: 42px;
+.user-css-presentation h1,
+.user-css-presentation h1 a,
+.user-css-presentation .world-title {
+    font-size: 5rem;
     font-family: Mina, serif;
+    font-weight: 500;
+    padding: initial;
 }
 
 .user-css-presentation h1 .btn {
-    font-size: 20px;
+    font-size: 2rem;
+    margin-bottom: 5px;
 }
 
 .user-css-presentation h2 {
-    font-size: 30px;
-    font-family: Mina, serif;
     border-bottom: 1px solid;
-    font-weight: 100;
+    font-family: Mina, serif;
+    font-size: 3rem;
+    font-weight: 500;
+    margin-bottom: 5px;
     margin-top: 25px;
+    padding-bottom: initial;
+    text-transform: initial;
 }
 
 .user-css-presentation h3 {
-    font-family: Mina, serif;
-    font-size: 24px;
-    margin-top: 15px;
-    margin-bottom: 0;
     border-bottom: 1px solid;
+    font-family: Mina, serif;
+    font-size: 2.4rem;
+    font-weight: 500;
+    margin-bottom: 5px;
+    margin-top: 15px;
 }
 
-.user-css-presentation h4 {
+.user-css-presentation h4,
+.user-css-presentation .organization-motto h4 {
     font-family: Mina, serif;
-    font-size: 20px;
-    text-transform: uppercase;
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 5px;
     margin-top: 10px;
-    margin-bottom: 0;
+    text-transform: uppercase;
 }
 
 .user-css-presentation h5 {
     font-family: Mina, serif;
-    font-size: 16px;
-    text-transform: uppercase;
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin-bottom: 5px;
     margin-top: 5px;
-    margin-bottom: 0;
+    text-transform: uppercase;
 }
 
 .user-css-presentation h6 {
     font-family: Mina, serif;
-    font-size: 14px;
-    text-transform: uppercase;
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin-bottom: 5px;
     margin-top: 5px;
-    margin-bottom: 0;
+    text-transform: uppercase;
 }
 
 .user-css-presentation img {
-    border-radius: 5px;
+    border-radius: var(--borderRadius);
 }
 
-.user-css-presentation .user-css-image-thumbnail {
-    border-radius: 5px;
-    padding: 0;
-    margin: 10px;
-}
-
-.user-css-presentation .user-css-image-thumbnail img {
-    border-radius: 5px 5px 0 0;
+.user-css-presentation li {
+    padding: 2px 0 2px 2px;
 }
 
 .user-css-presentation p {
@@ -136,18 +1228,18 @@
     line-height: 1.4em;
 }
 
-.user-css-presentation textarea, .user-css-presentation .typeahead-input {
+.user-css-presentation textarea {
     border: none;
-    border-radius: 3px;
+    border-radius: var(--borderRadiusSmall);
     margin-bottom: 5px;
 }
 
 /* LAYOUT - BOOTSTRAP CLASSES */
 .user-css-presentation .alert {
-    border-radius: 4px;
+    border-radius: var(--borderRadius);
     border: none;
     border-left: 34px solid;
-    font-size: 13px;
+    font-size: 1.3rem;
     padding: 5px 10px;
     text-align: justify;
     width: 85%;
@@ -170,17 +1262,24 @@
 
 .user-css-presentation .btn {
     border: none !important;
-    border-radius: 3px;
+    border-radius: var(--borderRadiusSmall);
+    font-family: inherit;
+    font-size: 1.4rem;
     margin: 2px 1px;
 }
 
 .user-css-presentation .breadcrumb {
-    font-size: 80%;
+    font-size: 1.2rem;
 }
 
 .user-css-presentation .breadcrumb li .active {
     font-weight: bold;
     display: inline-block;
+}
+
+.user-css-presentation .card-box {
+    border: none;
+    border-radius: var(--borderRadius);
 }
 
 .user-css-presentation .spoiler-button {
@@ -189,18 +1288,30 @@
 
 .user-css-presentation .label {
     border: none;
-    border-radius: 3px;
+    border-radius: var(--borderRadiusSmall);
+    font-weight: normal;
+    font-size: 1.1rem;
+    padding: .3em .5em;
+    margin: .5em .1em;
 }
 
 .user-css-presentation .nav-tabs {
     border: none;
     border-bottom: 1px solid;
+    margin: 0 -10px;
+    position: initial;
 }
 
-.user-css-presentation .nav-tabs li a, .user-css-presentation .nav-tabs li a:hover {
-    border-radius: 4px 4px 0 0;
-    margin: 3px 3px 0 3px;
+.user-css-presentation .nav-tabs li a,
+.user-css-presentation .nav-tabs li a:hover,
+.user-css-presentation .av-tabs li.active a {
     border: none;
+    border-radius: var(--borderRadius) var(--borderRadius) 0 0;
+    font-family: inherit;
+    font-size: inherit;
+    margin: 3px 3px 0 3px;
+    padding: 0 20px;
+    text-transform: uppercase;
 }
 
 .user-css-presentation .nav-tabs li.active a {
@@ -208,11 +1319,17 @@
     border-bottom: none;
 }
 
-.user-css-presentation .panel, .user-css-presentation .panel-npcsheet {
-    margin-bottom: 20px;
+.user-css-presentation .panel,
+.user-css-presentation .panel-npcsheet {
+    background: none;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--borderRadius);
+    margin-bottom: 20px;
     padding: 3px 5px;
+}
+
+.user-css-presentation .panel dl {
+    margin-bottom: 0;
 }
 
 .user-css-presentation .panel-heading {
@@ -228,9 +1345,11 @@
 }
 
 .user-css-presentation .table {
+    background: transparent;
     border: none;
     border-collapse: collapse;
-    border-radius: 7px;
+    border-radius: var(--borderRadius);
+    font-family: inherit;
     overflow: hidden;
 }
 
@@ -238,27 +1357,57 @@
     background: transparent !important;
 }
 
-.user-css-presentation .table td, .user-css-presentation .table th {
+.user-css-presentation .table td,
+.user-css-presentation .table th {
     border: none;
+    font-family: inherit;
+    text-align: left;
 }
 
 .user-css-presentation .well {
+    background: none;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--borderRadius);
 }
 
 /* LAYOUT - WORLDANVIL CLASSES */
-.user-css-presentation .aloud, .user-css-presentation .panel-greatgm {
-    border-radius: 4px;
+.user-css-presentation .aloud {
+    background: none;
+    border-radius: var(--borderRadius);
     border: none;
 }
 
-.user-css-presentation .artist-credits {
-    border-radius: 5px;
+.user-css-presentation .article-content {
+    font-size: inherit;
 }
 
-.user-css-presentation .user-css-image-thumbnail .artist-credits {
-    border-radius: 0 0 5px 5px;
+.user-css-presentation .article-subheading {
+    font-weight: 500;
+    padding: initial;
+}
+
+.user-css-presentation .article-title {
+    padding-top: 20px;
+    padding-left: 35px;
+}
+
+.user-css-presentation .article-title-author {
+    font-family: inherit;
+    font-size: 1em;
+    padding: initial;
+}
+
+.user-css-presentation .artist-credits {
+    border-radius: var(--borderRadius);
+    padding: 2px 4px;
+    text-align: center;
+}
+
+.user-css-presentation .author-item,
+.user-css-presentation .world-author {
+    font-family: inherit;
+    font-size: 1.6rem;
+    padding: 5px;
 }
 
 .user-css-presentation .text-abbreviation {
@@ -269,53 +1418,118 @@
 
 .user-css-presentation .article-panel {
     border: none;
-    border-radius: 5px;
+    border-radius: var(--borderRadius);
+    margin-bottom: 15px;
     padding: 0;
 }
 
 .user-css-presentation .article-panel a {
+    display: inline-block;
     padding: 10px;
     width: 100%;
     height: 100%;
 }
 
+.user-css-presentation .article-panel .details {
+    text-align: center;
+}
+
+.user-css-presentation .article-panel .details p {
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 5px;
+    text-align: left;
+}
+
 .user-css-presentation .backtoworld a {
-    left: -8px;
     border: none;
-    border-radius: 0 3px 3px 0;
+    border-radius: 0 var(--borderRadiusSmall) var(--borderRadiusSmall) 0;
+    font-family: inherit;
+    font-size: 1.2rem;
+    font-weight: bold;
+    left: -8px;
+    padding: 7px 13px;
+    top: -16px;
+}
+
+/* Temporary hotfix for character sheet readability */
+.user-css-presentation .character-sheet {
+    color: black;
 }
 
 .user-css-presentation .comment-box {
+    background: none;
     border: none;
-    border-radius: 5px;
+    border-radius: var(--borderRadius);
     margin-bottom: 5px;
+    padding-left: 5px;
+}
+
+.user-css-presentation .comment-box-author {
+    font-family: Mina, serif;
+    font-size: 2rem;
+    padding-left: initial;
+    padding-top: 10px;
+}
+
+.user-css-presentation .comment-box-date {
+    padding-left: initial;
+}
+
+.user-css-presentation .comment-box-content {
+    padding-left: initial;
+    padding-top: 10px;
+}
+
+.user-css-presentation .comment-box-reply {
+    border-top: 1px solid;
+    margin-top: 20px;
+    padding-top: 10px;
 }
 
 .user-css-presentation .comment-box p {
     font-size: 1.2em;
 }
 
-.user-css-presentation .cover, .user-css-presentation .cover img {
-    border-radius: 5px 5px 0 0;
+.user-css-presentation .cover,
+.user-css-presentation .cover img {
+    border-radius: var(--borderRadius) var(--borderRadius) 0 0;
 }
 
 .user-css-presentation .dropcap {
     font-family: Mina, serif;
+    font-size: 4em;
+    font-weight: inherit;
+    line-height: 60px;
+    padding: 4px 8px 4px 0;
+    text-transform: initial;
 }
 
 .user-css-presentation .map-box {
-    border-radius: 5px;
+    border-radius: var(--borderRadius);
     padding: 0;
     margin: 10px;
+    text-align: center;
 }
 
 .user-css-presentation .map-box img {
-    border-radius: 5px 5px 0 0;
+    border-radius: var(--borderRadius) var(--borderRadius) 0 0;
+    padding-bottom: 0;
 }
 
 .user-css-presentation .map-box div {
     padding: 5px;
-    border-radius: 0 0 5px 5px;
+    border-radius: 0 0 var(--borderRadius) var(--borderRadius);
+}
+
+.user-css-presentation .map-box p,
+.user-css-presentation .map-box small {
+    font-family: inherit;
+    font-style: inherit;
+    font-weight: inherit;
+    font-size: 1.2rem;
+    padding: 0 10px;
+    margin-bottom: 0;
 }
 
 .user-css-presentation .map-box div p:last-child {
@@ -323,11 +1537,25 @@
 }
 
 .user-css-presentation .menu-control {
+    background: none;
     border: none;
-    background-image: none;
-    border-radius: 0 0 3px 3px;
-    padding: 4px 0 0 0;
+    border-radius: 0 0 var(--borderRadiusSmall) var(--borderRadiusSmall);
+    font-size: 1.4rem;
     height: 32px;
+    padding: 4px 0 0 0;
+    top: 2px;
+}
+
+.user-css-presentation .nav-strip {
+    font-family: inherit;
+    font-size: 1.4rem;
+    font-weight: inherit;
+}
+
+.user-css-presentation .panel-greatgm {
+    font-size: 1.1em;
+    margin: 20px;
+    opacity: 1;
 }
 
 .user-css-presentation .phrase-key {
@@ -341,13 +1569,35 @@
 
 .user-css-presentation .relation .relationScore {
     border: none;
-    border-radius: 3px;
+    border-radius: var(--borderRadiusSmall);
     margin-bottom: 5px;
 }
 
-.user-css-secret {
+.user-css-presentation .search-form {
+    left: 25px;
+    margin: 5px;
+}
+
+.user-css-presentation .search-form .btn {
+    padding: inherit !important;
+    padding-right: 6px !important;
+}
+
+.user-css-presentation .search-form .typeahead-input {
     border: none;
-    border-radius: 5px;
+    border-radius: var(--borderRadiusSmall);
+    font-size: 1.4rem;
+    height: 25px;
+    margin-bottom: 5px;
+    padding: 6px 12px;
+    text-transform: capitalize;
+    width: 180px;
+}
+
+.user-css-secret {
+    background: none;
+    border: none;
+    border-radius: var(--borderRadius);
 }
 
 .user-css-secret .spoiler-content {
@@ -363,36 +1613,37 @@
 .user-css-presentation .statblock {
     margin-bottom: 20px;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--borderRadius);
     padding: 3px 5px;
 }
 
-/* Temporary hotfix for character sheet readability */
-.user-css-presentation .character-sheet {
-    color: black;
-}
-
-.user-css-presentation .label {
-    font-weight: normal;
-    font-size: 11px;
-}
-
-.user-css-presentation  .label.tag:hover {
+.user-css-presentation .label.tag:hover {
     font-weight: normal;
     border: none;
-    border-radius: 3px;
+    border-radius: var(--borderRadiusSmall);
 }
 
-.user-css-presentation .timeline li .timeline-panel {
+.user-css-presentation .timeline li .timeline-panel,
+.user-css-presentation .timeline li.milestone {
     border-bottom: none;
     border-left: none;
     border-right: none;
     border-top: 8px solid;
-    border-radius: 4px;
+    border-radius: var(--borderRadius);
+    box-shadow: none;
 }
 
-.user-css-presentation .timeline li .timeline-panel .header-icon {
+.user-css-presentation .timeline li .header-icon {
     padding: 12.5px;
+}
+
+.user-css-presentation .timeline li .header-icon .ra-3x {
+    font-size: 40px;
+}
+
+.user-css-presentation .timeline li .timeline-panel::before,
+.user-css-presentation .timeline li .timeline-panel::after {
+    top: 30px;
 }
 
 .user-css-presentation .tooltip {
@@ -401,12 +1652,26 @@
 
 .user-css-presentation .tooltip .tooltip-inner {
     border: none;
-    border-radius: 4px;
+    border-radius: var(--borderRadius);
 }
 
 .user-css-presentation .user-box {
     padding: 8px;
     height: 76px;
+}
+
+.user-css-presentation .user-css-image-thumbnail {
+    border-radius: var(--borderRadius);
+    padding: 0;
+    margin: 10px;
+}
+
+.user-css-presentation .user-css-image-thumbnail .artist-credits {
+    border-radius: 0 0 var(--borderRadius) var(--borderRadius);
+}
+
+.user-css-presentation .user-css-image-thumbnail img {
+    border-radius: var(--borderRadius) var(--borderRadius) 0 0;
 }
 
 .user-css-presentation .page-image .image-block p {
@@ -505,8 +1770,10 @@
     border-right: none;
 }
 
-.user-css-presentation .row-border-group .user-row .col-md-6:after, .user-css-presentation .row-border-group .user-row .col-md-6:before,
-.user-css-presentation .row-border-group .user-row .col-md-4:after, .user-css-presentation .row-border-group .user-row .col-md-4:before,
+.user-css-presentation .row-border-group .user-row .col-md-6:after,
+.user-css-presentation .row-border-group .user-row .col-md-6:before,
+.user-css-presentation .row-border-group .user-row .col-md-4:after,
+.user-css-presentation .row-border-group .user-row .col-md-4:before,
 .user-css-presentation .row-border-group .user-row .col-md-12:after
 {
     content: url(https://www.worldanvil.com/themes/galaxyanvil/images/empty.gif);
@@ -623,40 +1890,48 @@
     width: 100%;
 }
 
-.user-css-presentation .page, .user-css-presentation .worldmenu-inner {
+.user-css-presentation .page {
     background-color: var(--default3Transparent);
     color: var(--defaultDMuted);
     box-shadow: 0 0 11px 2px var(--default3Transparent);
 }
 
 .user-css-presentation .worldmenu-inner {
-    background-color: var(--primary3Transparent) !important;
-    color: var(--primaryDMuted);
-    box-shadow: 0 0 11px 2px var(--primary3Transparent);
+    background-color: var(--accent3Transparent) !important;
+    color: var(--accentDMuted);
+    box-shadow: 0 0 11px 2px var(--accent3Transparent);
 }
 
 /* HEADINGS */
-.user-css-presentation h1, .user-css-presentation h1 a {
+.user-css-presentation h1,
+.user-css-presentation h1 a,
+.user-css-presentation .world-title {
     color: var(--primaryA);
     background: linear-gradient(var(--defaultA), var(--primaryA), var(--accentA));
+    background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
 
 .user-css-presentation h1 .btn {
+    background-clip: initial;
     -webkit-background-clip: initial;
     -webkit-text-fill-color: initial;
 }
 
-.user-css-presentation h1 small, .user-css-presentation h1 a small, .user-css-presentation h4.article-subheading {
+.user-css-presentation h1 small,
+.user-css-presentation h1 a small,
+.user-css-presentation h4.article-subheading {
     color: var(--primary8);
     background: linear-gradient(var(--default8), var(--primary8), var(--accent8));
+    background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
 
 .user-css-presentation h4.article-subheading {
     background: linear-gradient(var(--accent8), var(--primary8), var(--default8));
+    background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
@@ -707,7 +1982,11 @@
 }
 
 /* LINKS */
-.user-css-presentation a, .user-css-presentation a:focus {
+.user-css-presentation a,
+.user-css-presentation a:focus,
+.user-css-presentation .user-css-image-thumbnail .artist-credits a,
+.user-css-presentation .timeline li .timeline-panel a:not(.label),
+.user-css-presentation .timeline li .milestone-panel a:not(.label) {
     color: var(--primaryD);
 }
 
@@ -715,7 +1994,8 @@
     color: var(--primaryC);
 }
 
-.user-css-presentation a:hover, .user-css-presentation .text-abbreviation:hover {
+.user-css-presentation a:hover,
+.user-css-presentation .text-abbreviation:hover {
     color: var(--primaryDMuted);
 }
 
@@ -743,7 +2023,8 @@
     color: var(--primaryAMuted);
 }
 
-.user-css-presentation blockquote small, .user-css-presentation blockquote .author small {
+.user-css-presentation blockquote small,
+.user-css-presentation blockquote .author small {
     color: var(--primary8Muted);
 }
 
@@ -779,6 +2060,50 @@
 
 .user-css-presentation .alert-secondary h5:first-child {
     color: var(--accentDMuted);
+}
+
+.user-css-presentation .alert-info {
+    background-color: var(--info3Transparent);
+    border-color: var(--info9Transparent);
+    color: var(--infoDMuted);
+    box-shadow: 0 0 2px 2px var(--info9Transparent);
+}
+
+.user-css-presentation .alert-info h5:first-child {
+    color: var(--infoDMuted);
+}
+
+.user-css-presentation .alert-success {
+    background-color: var(--success3Transparent);
+    border-color: var(--success9Transparent);
+    color: var(--successDMuted);
+    box-shadow: 0 0 2px 2px var(--success9Transparent);
+}
+
+.user-css-presentation .alert-success h5:first-child {
+    color: var(--successDMuted);
+}
+
+.user-css-presentation .alert-warning {
+    background-color: var(--warning3Transparent);
+    border-color: var(--warning9Transparent);
+    color: var(--warningDMuted);
+    box-shadow: 0 0 2px 2px var(--warning9Transparent);
+}
+
+.user-css-presentation .alert-warning h5:first-child {
+    color: var(--warningDMuted);
+}
+
+.user-css-presentation .alert-danger {
+    background-color: var(--danger3Transparent);
+    border-color: var(--danger9Transparent);
+    color: var(--dangerDMuted);
+    box-shadow: 0 0 2px 2px var(--danger9Transparent);
+}
+
+.user-css-presentation .alert-danger h5:first-child {
+    color: var(--dangerDMuted);
 }
 
 /* ALOUD */
@@ -861,6 +2186,46 @@
     background: var(--accentDTransparent) !important;
 }
 
+.user-css-presentation .btn-info {
+    color: var(--accentDMuted) !important;
+    background: var(--accentATransparent) !important;
+}
+
+.user-css-presentation .btn-info:hover {
+    color: var(--accentEMuted) !important;
+    background: var(--accentDTransparent) !important;
+}
+
+.user-css-presentation .btn-success {
+    color: var(--accentDMuted) !important;
+    background: var(--accentATransparent) !important;
+}
+
+.user-css-presentation .btn-success:hover {
+    color: var(--accentEMuted) !important;
+    background: var(--accentDTransparent) !important;
+}
+
+.user-css-presentation .btn-warning {
+    color: var(--accentDMuted) !important;
+    background: var(--accentATransparent) !important;
+}
+
+.user-css-presentation .btn-warning:hover {
+    color: var(--accentEMuted) !important;
+    background: var(--accentDTransparent) !important;
+}
+
+.user-css-presentation .btn-danger {
+    color: var(--accentDMuted) !important;
+    background: var(--accentATransparent) !important;
+}
+
+.user-css-presentation .btn-danger:hover {
+    color: var(--accentEMuted) !important;
+    background: var(--accentDTransparent) !important;
+}
+
 .user-css-presentation .btn-link {
     color: var(--primaryD);
 }
@@ -869,19 +2234,40 @@
     color: var(--primaryDMuted);
 }
 
+/* CARDS */
+.user-css-presentation .card-box {
+    background-color: var(--default3Transparent);
+    box-shadow: 0 0 2px 2px var(--default3Transparent);
+    color: var(--defaultEMuted);
+}
+
+.user-css-presentation .card-box:hover {
+    background-color: var(--default5Transparent);
+    box-shadow: 0 0 2px 2px var(--default5Transparent);
+}
+
 /* COMMENT BOX */
 .user-css-presentation .comment-box {
     background-color: var(--default3Transparent);
     box-shadow: 0 0 2px 2px var(--defaultATransparent);
 }
 
+.user-css-presentation .comment-box-reply {
+    border-color: var(--defaultAMuted);
+}
+
 /* LABELS */
-.user-css-presentation .label-default {
+.user-css-presentation .label-default,
+.user-css-presentation .timeline li .timeline-panel a.label,
+.user-css-presentation .timeline li .milestone-panel a.label {
     background: var(--defaultAMuted);
     color: var(--default3Muted);
 }
 
-.user-css-presentation a.label-default:hover, .user-css-presentation a .label-default:hover {
+.user-css-presentation a.label-default:hover,
+.user-css-presentation a .label-default:hover,
+.user-css-presentation .timeline li .timeline-panel a.label:hover,
+.user-css-presentation .timeline li .milestone-panel a.label:hover {
     background: var(--defaultDMuted);
     color: var(--default3Muted);
 }
@@ -891,7 +2277,8 @@
     color: var(--primary3Muted);
 }
 
-.user-css-presentation a.label-primary:hover, .user-css-presentation a .label-primary:hover {
+.user-css-presentation a.label-primary:hover,
+.user-css-presentation a .label-primary:hover {
     background: var(--primaryDMuted);
     color: var(--primary3Muted);
 }
@@ -901,49 +2288,54 @@
     color: var(--accent3Muted);
 }
 
-.user-css-presentation a.label-secondary:hover, .user-css-presentation a .label-secondary:hover {
+.user-css-presentation a.label-secondary:hover,
+.user-css-presentation a .label-secondary:hover {
     background: var(--accentDMuted);
     color: var(--accent3Muted);
 }
 
 .user-css-presentation .label-info {
-    background: #aababa;
-    color: #334343;
+    background: var(--infoAMuted);
+    color: var(--info3Muted);
 }
 
-.user-css-presentation a.label-info:hover, .user-css-presentation a .label-info:hover {
-    background: #eeeded;
-    color: #334343;
+.user-css-presentation a.label-info:hover,
+.user-css-presentation a .label-info:hover {
+    background: var(--infoDMuted);
+    color: var(--info3Muted);
 }
 
 .user-css-presentation .label-success {
-    background: #aabaaa;
-    color: #334333;
+    background: var(--successAMuted);
+    color: var(--success3Muted);
 }
 
-.user-css-presentation a.label-success:hover, .user-css-presentation a .label-success:hover {
-    background: #eeedee;
-    color: #334333;
+.user-css-presentation a.label-success:hover,
+.user-css-presentation a .label-success:hover {
+    background: var(--successDMuted);
+    color: var(--success3Muted);
 }
 
 .user-css-presentation .label-warning {
-    background: #babaaa;
-    color: #434333;
+    background: var(--warningAMuted);
+    color: var(--warning3Muted);
 }
 
-.user-css-presentation a.label-warning:hover, .user-css-presentation a .label-warning:hover {
-    background: #ededee;
-    color: #434333;
+.user-css-presentation a.label-warning:hover,
+.user-css-presentation a .label-warning:hover {
+    background: var(--warningDMuted);
+    color: var(--warning3Muted);
 }
 
 .user-css-presentation .label-danger {
-    background: #baaaaa;
-    color: #433333;
+    background: var(--dangerAMuted);
+    color: var(--danger3Muted);
 }
 
-.user-css-presentation a.label-danger:hover, .user-css-presentation a .label-danger:hover {
-    background: #edeeee;
-    color: #433333;
+.user-css-presentation a.label-danger:hover,
+.user-css-presentation a .label-danger:hover {
+    background: var(--dangerDMuted);
+    color: var(--danger3Muted);
 }
 
 /* NAV */
@@ -1000,7 +2392,8 @@
     color: var(--defaultDMuted);
 }
 
-.user-css-presentation .panel .panel-heading small, .user-css-presentation .panel .panel-heading .text-muted {
+.user-css-presentation .panel .panel-heading small,
+.user-css-presentation .panel .panel-heading .text-muted {
     color: var(--defaultCMuted);
 }
 
@@ -1019,18 +2412,21 @@
     color: var(--accentDMuted);
 }
 
-.user-css-presentation .panel-default .panel-heading small, .user-css-presentation .panel-default .panel-heading .text-muted {
+.user-css-presentation .panel-default .panel-heading small,
+.user-css-presentation .panel-default .panel-heading .text-muted {
     color: var(--accentCMuted);
 }
 
-.user-css-presentation .panel-primary, .user-css-presentation .panel-npcsheet {
+.user-css-presentation .panel-primary,
+.user-css-presentation .panel-npcsheet {
     background-color: var(--primary3Transparent);
     border-color: var(--primaryDTransparent);
     color: var(--primaryDMuted);
     box-shadow: 0 0 2px 2px var(--primaryDTransparent);
 }
 
-.user-css-presentation .panel-primary hr, .user-css-presentation .panel-npcsheet hr {
+.user-css-presentation .panel-primary hr,
+.user-css-presentation .panel-npcsheet hr {
     border-color: var(--primaryA);
 }
 
@@ -1042,7 +2438,8 @@
     color: var(--primaryDMuted);
 }
 
-.user-css-presentation .panel-primary .panel-heading small, .user-css-presentation .panel-primary .panel-heading .text-muted {
+.user-css-presentation .panel-primary .panel-heading small,
+.user-css-presentation .panel-primary .panel-heading .text-muted {
     color: var(--primaryCMuted);
 }
 
@@ -1129,6 +2526,22 @@
     background-image: linear-gradient(to left, var(--defaultAFullTransparent), var(--accentA), var(--defaultAFullTransparent));
 }
 
+/* SECRETS */
+.user-css-secret {
+    background-color: var(--primary3Transparent);
+    color: var(--primaryDMuted);
+    -webkit-box-shadow: 0 0 2px 2px var(--primary3Transparent);
+    box-shadow: 0 0 2px 2px var(--primary3Transparent);
+}
+
+.user-css-secret h5 {
+    color: var(--primaryAMuted);
+}
+
+.user-css-secret small, .user-css-secret .text-muted {
+    color: var(--primary8Muted);
+}
+
 /* SPOILERS */
 .user-css-presentation .spoiler-content {
     background-color: var(--accent3Transparent);
@@ -1199,50 +2612,9 @@
     background: var(--accent5Transparent);
 }
 
-.user-css-presentation .map-box div {
-    background: var(--primary5Transparent);
-    color: var(--primaryDMuted);
-}
-
-.user-css-presentation .map-box small {
-    color: var(--primaryDMuted);
-}
-
-/* TIMELINES */
-.user-css-presentation .timeline:before {
-    background: var(--accentA);
-    box-shadow: 0 0 2px 1px var(--accentA);
-}
-
-.user-css-presentation .timeline li .tl-circ {
-    background: var(--accent2);
-    border-color: var(--accentA);
-    box-shadow: 0 0 2px 1px var(--accentA);
-}
-
-.user-css-presentation .timeline li .timeline-panel {
-    background: var(--accent3Transparent);
+.user-css-presentation .map-box small,
+.user-css-presentation .map-box p {
     color: var(--accentDMuted);
-    box-shadow: 0 0 2px 2px var(--accent3Transparent);
-}
-
-.user-css-presentation .timeline li .timeline-panel:before, .user-css-presentation .timeline li .timeline-panel:after {
-    border-left-color: var(--accentA);
-    border-right-color: var(--accentA);
-}
-
-.user-css-presentation .timeline li .timeline-panel .header-icon {
-    border-color: var(--accentA);
-    color: var(--accentA);
-    background: var(--accent1);
-}
-
-.user-css-presentation .timeline li .timeline-panel h4 {
-    color: var(--accentA);
-}
-
-.user-css-presentation .timeline li .timeline-panel h4 small {
-    color: var(--accent9);
 }
 
 /* TOOLTIPS */
@@ -1270,31 +2642,42 @@
 }
 
 /* CODE/PRE */
-.user-css-presentation code, .user-css-presentation pre, .user-css-presentation .panel code {
+.user-css-presentation code,
+.user-css-presentation pre,
+.user-css-presentation .panel code {
     background-color: var(--defaultDMuted);
     color: var(--default2Muted);
 }
 
-.user-css-presentation blockquote code, .user-css-presentation blockquote pre, .user-css-presentation .panel-primary code, .user-css-presentation .panel-primary pre {
+.user-css-presentation blockquote code,
+.user-css-presentation blockquote pre,
+.user-css-presentation .panel-primary code,
+.user-css-presentation .panel-primary pre {
     background-color: var(--primaryE);
     color: var(--primary1Muted);
 }
 
-.user-css-presentation .panel-default code, .user-css-presentation .panel-default pre {
+.user-css-presentation .panel-default code,
+.user-css-presentation .panel-default pre {
     background-color: var(--accentE);
     color: var(--accent1Muted);
 }
 
 /* SMALL/TEXT_Muted */
-.user-css-presentation small, .user-css-presentation .text-muted {
+.user-css-presentation small,
+.user-css-presentation .text-muted {
     color: var(--default8Muted);
 }
 
-.user-css-presentation .panel-default small, .user-css-presentation .panel-default .text-muted, .user-css-presentation .spoiler-content small, .user-css-presentation .spoiler-content .text-muted {
+.user-css-presentation .panel-default small,
+.user-css-presentation .panel-default .text-muted,
+.user-css-presentation .spoiler-content small,
+.user-css-presentation .spoiler-content .text-muted {
     color: var(--accent8Muted);
 }
 
-.user-css-presentation .panel-primary small, .user-css-presentation .panel-primary .text-muted {
+.user-css-presentation .panel-primary small,
+.user-css-presentation .panel-primary .text-muted {
     color: var(--primary8Muted);
 }
 
@@ -1306,1337 +2689,404 @@
 }
 
 /* FORM INPUTS */
-.user-css-presentation textarea, .user-css-presentation .typeahead-input {
+.user-css-presentation textarea,
+.user-css-presentation .typeahead-input {
     background-color: var(--accent5Transparent);
     color: var(--accentDMuted);
     box-shadow: 0 0 2px 2px var(--accent5Transparent);
 }
 
-.user-css-presentation textarea:focus, .user-css-presentation .typeahead-input:focus {
+.user-css-presentation textarea:focus,
+.user-css-presentation .typeahead-input:focus {
     box-shadow: 0 0 2px 2px var(--accentATransparent);
 }
 
-
-/* HARDCODED COLORS */
-/* ALERTS */
-.user-css-presentation .alert-success {
-    background-color: rgba(0, 66, 0, 0.5);
-    border-color: rgba(0, 201, 0, 0.5);
-    color: #DCEADC;
-    -webkit-box-shadow: 0 0 2px 2px rgba(0, 201, 0, 0.5);
-    box-shadow: 0 0 2px 2px rgba(0, 201, 0, 0.5);
+.user-css-presentation .typeahead-input .btn {
+    color: var(--primaryD) !important;
 }
 
-.user-css-presentation .alert-success h5:first-child {
-    color: #DCEADC;
-}
-
-.user-css-presentation .alert-info {
-    background-color: rgba(0, 66, 66, 0.5);
-    border-color: rgba(0, 201, 201, 0.5);
-    color: #DCEAEA;
-    -webkit-box-shadow: 0 0 2px 2px rgba(0, 201, 201, 0.5);
-    box-shadow: 0 0 2px 2px rgba(0, 201, 201, 0.5);
-}
-
-.user-css-presentation .alert-info h5:first-child {
-    color: #DCEAEA;
-}
-
-.user-css-presentation .alert-warning {
-    background-color: rgba(66, 66, 0, 0.5);
-    border-color: rgba(201, 201, 0, 0.5);
-    color: #EAEADC;
-    -webkit-box-shadow: 0 0 2px 2px rgba(201, 201, 0, 0.5);
-    box-shadow: 0 0 2px 2px rgba(201, 201, 0, 0.5);
-}
-
-.user-css-presentation .alert-warning h5:first-child {
-    color: #EAEADC;
-}
-
-.user-css-presentation .alert-danger {
-    background-color: rgba(66, 0, 0, 0.5);
-    border-color: rgba(201, 0, 0, 0.5);
-    color: #EADCDC;
-    -webkit-box-shadow: 0 0 2px 2px rgba(201, 0, 0, 0.5);
-    box-shadow: 0 0 2px 2px rgba(201, 0, 0, 0.5);
-}
-
-.user-css-presentation .alert-danger h5:first-child {
-    color: #EADCDC;
-}
-
-/* BUTTONS */
-.user-css-presentation .btn-info {
-    color: #ddeded !important;
-    background: rgba(0, 186, 186, 0.5) !important;
-}
-
-.user-css-presentation .btn-info:hover {
-    color: #eefefe !important;
-    background: rgba(0, 237, 237, 0.5) !important;
-}
-
-.user-css-presentation .btn-success {
-    color: #ddeddd !important;
-    background: rgba(0, 186, 0, 0.5) !important;
-}
-
-.user-css-presentation .btn-success:hover {
-    color: #eefeee !important;
-    background: rgba(0, 237, 0, 0.5) !important;
-}
-
-.user-css-presentation .btn-warning {
-    color: #ededdd !important;
-    background: rgba(186, 186, 0, 0.5) !important;
-}
-
-.user-css-presentation .btn-warning:hover {
-    color: #fefeee !important;
-    background: rgba(237, 237, 0, 0.5) !important;
-}
-
-.user-css-presentation .btn-danger {
-    color: #eddddd !important;
-    background: rgba(186, 0, 0, 0.5) !important;
-}
-
-.user-css-presentation .btn-danger:hover {
-    color: #feeeee !important;
-    background: rgba(237, 0, 0, 0.5) !important;
-}
-
-/* SECRETS */
-.user-css-secret {
-    background-color: rgba(67, 0, 0, 0.5);
-    color: #eddddd;
-    -webkit-box-shadow: 0 0 2px 2px rgba(67, 0, 0, 0.5);
-    box-shadow: 0 0 2px 2px rgba(67, 0, 0, 0.5);
-}
-
-.user-css-secret h5 {
-    color: #caaaaa;
-}
-
-.user-css-secret small {
-    color: #988888;
+.user-css-presentation .search-form .btn:hover {
+    color: var(--primaryDMuted) !important;
 }
 
 /* TIMELINES */
-.user-css-presentation .timeline li.important .tl-circ {
-    background: #211911;
-    border-color: #caca55;
-    box-shadow: 0 0 2px 1px #caca55;
-}
-
-.user-css-presentation .timeline li.major .tl-circ {
-    background: #211111;
-    border-color: #ca5555;
-    box-shadow: 0 0 2px 1px #ca5555;
-}
-
-.user-css-presentation .timeline li.minor .tl-circ {
-    background: #112111;
-    border-color: #55ca55;
-    box-shadow: 0 0 2px 1px #55ca55;
-}
-
-.user-css-presentation .timeline li.trivial .tl-circ {
-    background: #112121;
-    border-color: #55caca;
-    box-shadow: 0 0 2px 1px #55caca;
-}
-
-.user-css-presentation .timeline li.no-importance .tl-circ {
-    background: var(--accent1Muted);
-    border-color: var(--accentA);
+.user-css-presentation .timeline:before {
+    background: var(--accentA);
     box-shadow: 0 0 2px 1px var(--accentA);
 }
 
-.user-css-presentation .timeline li.important .timeline-panel:before, .user-css-presentation .timeline li.important .timeline-panel:after {
-    border-left-color: #caca55;
-    border-right-color: #caca55;
+.user-css-presentation .timeline li {
+    --tlBackground: var(--accent1Muted);
+    --tlBackground3: var(--accent3);
+    --tlBackground3Transparent: var(--accent3Transparent);
+    --tlBorder: var(--accentA);
+    --tlColor: var(--accentDMuted);
+    --tlColorMuted: var(--accent8Muted);
+    --tlColorHeader: var(--accentA);
+    --tlColorHeaderMuted: var(--accent8Muted);
 }
 
-.user-css-presentation .timeline li.major .timeline-panel:before, .user-css-presentation .timeline li.major .timeline-panel:after {
-    border-left-color: #ca5555;
-    border-right-color: #ca5555;
+.user-css-presentation .timeline li.milestone {
+    --tlBackground: var(--primary1Muted);
+    --tlBackground3: var(--primary3);
+    --tlBackground3Transparent: var(--primary3Transparent);
+    --tlBorder: var(--primaryA);
+    --tlColor: var(--primaryDMuted);
+    --tlColorMuted: var(--primary8Muted);
+    --tlColorHeader: var(--primaryA);
+    --tlColorHeaderMuted: var(--primary8Muted);
 }
 
-.user-css-presentation .timeline li.minor .timeline-panel:before, .user-css-presentation .timeline li.minor .timeline-panel:after {
-    border-left-color: #55ca55;
-    border-right-color: #55ca55;
+.user-css-presentation .timeline li.important {
+    --tlBackground: var(--warning1Muted);
+    --tlBackground3: var(--warning3);
+    --tlBackground3Transparent: var(--warning3Transparent);
+    --tlBorder: var(--warningA);
+    --tlColor: var(--warningDMuted);
+    --tlColorMuted: var(--warning8Muted);
+    --tlColorHeader: var(--warningA);
+    --tlColorHeaderMuted: var(--warning8Muted);
 }
 
-.user-css-presentation .timeline li.trivial .timeline-panel:before, .user-css-presentation .timeline li.trivial .timeline-panel:after {
-    border-left-color: #55caca;
-    border-right-color: #55caca;
+.user-css-presentation .timeline li.major {
+    --tlBackground: var(--danger1Muted);
+    --tlBackground3: var(--danger3);
+    --tlBackground3Transparent: var(--danger3Transparent);
+    --tlBorder: var(--dangerA);
+    --tlColor: var(--dangerDMuted);
+    --tlColorMuted: var(--danger8Muted);
+    --tlColorHeader: var(--dangerA);
+    --tlColorHeaderMuted: var(--danger8Muted);
 }
 
-.user-css-presentation .timeline li.no-importance .timeline-panel:before, .user-css-presentation .timeline li.no-importance .timeline-panel:after {
-    border-left-color: var(--accentA);
-    border-right-color: var(--accentA);
+.user-css-presentation .timeline li.minor {
+    --tlBackground: var(--success1Muted);
+    --tlBackground3: var(--success3);
+    --tlBackground3Transparent: var(--success3Transparent);
+    --tlBorder: var(--successA);
+    --tlColor: var(--successDMuted);
+    --tlColorMuted: var(--success8Muted);
+    --tlColorHeader: var(--successA);
+    --tlColorHeaderMuted: var(--success8Muted);
 }
 
-.user-css-presentation .timeline li.important .timeline-panel {
-    border-top-color: #caca55;
-    /* box-shadow: 0 0 2px 2px rgba(67, 59, 0, 0.5); */
-    /* background: rgba(67, 59, 0, 0.5); */
-    /* color: #ede5dd; */
+.user-css-presentation .timeline li.trivial {
+    --tlBackground: var(--info1Muted);
+    --tlBackground3: var(--info3);
+    --tlBackground3Transparent: var(--info3Transparent);
+    --tlBorder: var(--infoA);
+    --tlColor: var(--infoDMuted);
+    --tlColorMuted: var(--info8Muted);
+    --tlColorHeader: var(--infoA);
+    --tlColorHeaderMuted: var(--info8Muted);
 }
 
-.user-css-presentation .timeline li.important .timeline-panel .header-icon {
-    border-color: #caca55;
-    color: #caca55;
-    background: #211911;
+.user-css-presentation .timeline li .tl-circ {
+    background: var(--tlBackground);
+    border-color: var(--tlBorder);
+    box-shadow: 0 0 2px 1px var(--tlBorder);
 }
 
-.user-css-presentation .timeline li.important .timeline-panel h4 {
-    /* color: #cabaaa; */
+.user-css-presentation .timeline li .timeline-panel:before,
+.user-css-presentation .timeline li .timeline-panel:after {
+    border-left-color: var(--tlBorder);
+    border-right-color: var(--tlBorder);
 }
 
-.user-css-presentation .timeline li.important .timeline-panel h4 small {
-    /* color: #a9a199; */
+.user-css-presentation .timeline li .timeline-panel,
+.user-css-presentation .timeline li.milestone {
+    border-color: var(--tlBorder);
+    background: var(--tlBackground3Transparent);
+    color: var(--tlColor);
 }
 
-.user-css-presentation .timeline li.major .timeline-panel {
-    border-top-color: #ca5555;
-    /* box-shadow: 0 0 2px 2px rgba(67, 0, 0, 0.5); */
-    /* background: rgba(67, 0, 0, 0.5); */
-    /* color: #eddddd; */
+.user-css-presentation .timeline li .timeline-panel {
+    background: linear-gradient(to right, var(--tlBackground3Transparent), var(--tlBackground3Transparent), var(--tlBackground3));
 }
 
-.user-css-presentation .timeline li.major .timeline-panel .header-icon {
-    border-color: #ca5555;
-    color: #ca5555;
-    background: #211111;
+.user-css-presentation .timeline li.timeline-entry-inverted .timeline-panel {
+    background: linear-gradient(to left, var(--tlBackground3Transparent), var(--tlBackground3Transparent), var(--tlBackground3));
 }
 
-.user-css-presentation .timeline li.major .timeline-panel h4 {
-    /* color: #caaaaa; */
+.user-css-presentation .timeline li.milestone {
+    background: linear-gradient(to left, var(--tlBackground3Transparent), var(--tlBackground3), var(--tlBackground3Transparent));
 }
 
-.user-css-presentation .timeline li.major .timeline-panel h4 small {
-    /* color: #a99999; */
+.user-css-presentation .timeline li .timeline-panel .header-icon,
+.user-css-presentation .timeline li.milestone .header-icon {
+    border-color: var(--tlBorder);
+    color: var(--tlBorder);
+    background: var(--tlBackground);
 }
 
-.user-css-presentation .timeline li.minor .timeline-panel {
-    border-top-color: #55ca55;
-    /* box-shadow: 0 0 2px 2px rgba(0, 67, 0, 0.5); */
-    /* background: rgba(0, 67, 0, 0.5); */
-    /* color: #ddeddd; */
+.user-css-presentation .timeline li .timeline-panel h4,
+.user-css-presentation .timeline li .timeline-panel h5,
+.user-css-presentation .timeline li.milestone h4,
+.user-css-presentation .timeline li.milestone h5 {
+    color: var(--tlColorHeader);
 }
 
-.user-css-presentation .timeline li.minor .timeline-panel .header-icon {
-    border-color: #55ca55;
-    color: #55ca55;
-    background: #112111;
+.user-css-presentation .timeline li .timeline-panel h4 small,
+.user-css-presentation .timeline li .timeline-panel h5.text-muted,
+.user-css-presentation .timeline li.milestone h4 small,
+.user-css-presentation .timeline li.milestone h5.text-muted {
+    color: var(--tlColorHeaderMuted);
 }
 
-.user-css-presentation .timeline li.minor .timeline-panel h4 {
-    /* color: #aacaaa; */
+.user-css-presentation .timeline li .timeline-panel hr,
+.user-css-presentation .timeline li.milestone hr {
+    border-color: var(--tlColorHeader);
 }
 
-.user-css-presentation .timeline li.minor .timeline-panel h4 small {
-    /* color: #99a999; */
+.user-css-presentation .timeline li .timeline-panel p,
+.user-css-presentation .timeline li.milestone p {
+    color: inherit;
 }
 
-.user-css-presentation .timeline li.trivial .timeline-panel {
-    border-top-color: #55caca;
-    /* box-shadow: 0 0 2px 2px rgba(0, 67, 67, 0.5); */
-    /* background: rgba(0, 67, 67, 0.5); */
-    /* color: #ddeded; */
-}
-
-.user-css-presentation .timeline li.trivial .timeline-panel .header-icon {
-    border-color: #55caca;
-    color: #55caca;
-    background: #112121;
-}
-
-.user-css-presentation .timeline li.trivial .timeline-panel h4 {
-    /* color: #aacaca; */
-}
-
-.user-css-presentation .timeline li.trivial .timeline-panel h4 small {
-    /* color: #99a9a9; */
-}
-
-.user-css-presentation .timeline li.no-importance .timeline-panel {
-    border-top-color: var(--accentA);
-    /* box-shadow: 0 0 2px 2px var(--accent3Transparent); */
-    /* background: var(--accent3Transparent); */
-    /* color: var(--accentDMuted); */
-}
-
-.user-css-presentation .timeline li.no-importance .timeline-panel .header-icon {
-    border-color: var(--accentA);
-    color: var(--accentA);
-    background: var(--accent1Muted);
-}
-
-.user-css-presentation .timeline li.no-importance .timeline-panel h4 {
-    /* color: var(--accentA); */
-}
-
-.user-css-presentation .timeline li.no-importance .timeline-panel h4 small {
-    /* color: var(--accent9Muted); */
-}
-
-.user-css-presentation .timeline li.timeline-entry-milestone {
-    border-color: #aaaaaa;
-    background: #333333;
-    box-shadow: 0 0 2px 2px #333333;
-}
-
-.user-css-presentation .timeline li.timeline-entry-milestone .milestone-panel {
-    color: #dddddd;
-}
-
-.user-css-presentation .timeline li.timeline-entry-milestone .milestone-panel .header-icon {
-    border-color: #aaaaaa;
-    color: #aaaaaa;
-    background: #111111;
-}
-
-.user-css-presentation .timeline li.timeline-entry-milestone .milestone-panel h4 {
-    color: #aaaaaa;
-}
-
-.user-css-presentation .timeline li.timeline-entry-milestone .milestone-panel h4 small {
-    color: #999999;
+.user-css-presentation .timeline li .timeline-panel small,
+.user-css-presentation .timeline li .timeline-panel .text-muted,
+.user-css-presentation .timeline li.milestone small,
+.user-css-presentation .timeline li.milestone .text-muted {
+    color: var(--tlColorMuted);
 }
 
 /* TEXT */
 .user-css-presentation .text-success {
-    color: #55CA55;
+    color: var(--successD);
 }
 
 .user-css-presentation .text-warning {
-    color: #caca55;
+    color: var(--warningD);
 }
 
 .user-css-presentation .text-info {
-    color: #55caca;
+    color: vaR(--infoD);
 }
 
 .user-css-presentation .text-danger {
-    color: #ca5555;
+    color: var(--dangerD);
 }
 
-/* PERSONAL TWEAKS */
+/* Personal Tweaks */
 .user-css-presentation .article-block-hide-heading .article-panel .heading,
 .user-css-presentation .article-block-hide-subheading .article-panel .subheading,
 .user-css-presentation .article-block-hide-date .article-panel .date,
 .user-css-presentation .article-block-hide-excerpt .article-panel .excerpt,
 .user-css-presentation .article-block-hide-cover .article-panel .cover,
 .user-css-presentation .article-block-hide-details .article-panel .details {
-	display: none;
+    display: none;
 }
 
 .user-css-presentation .article-block-hide-details .article-panel .cover {
-	margin-bottom: -10px;
+    margin-bottom: -10px;
 }
 
 .user-css-presentation .paragraph-indent p {
-	text-indent: 25px;
+    text-indent: 25px;
 }
 
 .user-css-presentation .paragraph-indent :not(p), .user-css-presentation .paragraph-indent p * {
-	text-indent: 0;
+    text-indent: 0;
 }
 
 .user-css-presentation .line-spacer {
-	display: none;
+    display: none;
 }
 
 .user-css-presentation .comment-box .line-spacer, .user-css-presentation .panel-greatgm .line-spacer {
-	display: block;
+    display: block;
 }
 
 .user-css-presentation .flexbox-valign-middle {
-	display: flex;
-	align-items: center;
+    display: flex;
+    align-items: center;
 }
 
 .user-css-presentation .user-css.page, .user-css-presentation .user-css-extended .page, .user-css-presentation .user-css-worldmenu .worldmenu-inner {
-	background-color: var(--default3MutedTransparent);
+    background-color: var(--default3MutedTransparent);
 }
 
 .user-css-presentation .hide-sidebar .tab-content .col-md-4 {
-	display: none;
+    display: none;
 }
 
 .user-css-presentation .hide-sidebar .tab-content .col-md-8 {
-	width: 100%;
+    width: 100%;
 }
 
 .user-css-presentation .hide-sidebar .tab-content .col-md-8 .col-md-8 {
-	width: 66.6667%;
+    width: 66.6667%;
 }
 
 .user-css-presentation .hide-sidebar .tab-content .col-md-8 .col-md-4 {
-	display: block;
-}
-
-.user-css-presentation .alert-default {
-	border-color: var(--defaultETransparent);
-	box-shadow: 0 0 2px 2px var(--defaultETransparent);
-}
-
-.user-css-presentation .alert-default h5:first-child {
-	color: var(--default3);
-}
-
-.user-css-presentation .alert-primary {
-	border-color: var(--primaryETransparent);
-	box-shadow: 0 0 2px 2px var(--primaryETransparent);
-}
-
-.user-css-presentation .alert-primary h5:first-child {
-	color: var(--primary3);
-}
-
-.user-css-presentation .alert-secondary {
-	border-color: var(--accentETransparent);
-	box-shadow: 0 0 2px 2px var(--accentETransparent);
-}
-
-.user-css-presentation .alert-secondary h5:first-child {
-	color: var(--accent3);
-}
-
-.user-css-presentation .alert-danger {
-	border-color: var(--dangerETransparent);
-	box-shadow: 0 0 2px 2px var(--dangerETransparent);
-}
-
-.user-css-presentation .alert-danger h5:first-child {
-	color: var(--danger3);
-}
-
-.user-css-presentation .alert-warning {
-	border-color: var(--warningETransparent);
-	box-shadow: 0 0 2px 2px var(--warningETransparent);
-}
-
-.user-css-presentation .alert-warning h5:first-child {
-	color: var(--warning3);
-}
-
-.user-css-presentation .alert-success {
-	border-color: var(--successETransparent);
-	box-shadow: 0 0 2px 2px var(--successETransparent);
-}
-
-.user-css-presentation .alert-success h5:first-child {
-	color: var(--success3);
-}
-
-.user-css-presentation .alert-info {
-	border-color: var(--infoETransparent);
-	box-shadow: 0 0 2px 2px var(--infoETransparent);
-}
-
-.user-css-presentation .alert-info h5:first-child {
-	color: var(--info3);
+    display: block;
 }
 
 .user-css-presentation .relationScore {
-	display: none;
+    display: none;
 }
 
-/* Color Theme: Default (Midnight Dusk) */
-.user-css-presentation .user-css, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
-	/* Default Color: Muted Blue (Hue 65) */
-	--default1: #111121;
-	--default2: #222232;
-	--default3: #333343;
-	--default4: #444454;
-	--default5: #555565;
-	--default6: #666676;
-	--default7: #777787;
-	--default8: #888898;
-	--default9: #9999A9;
-	--defaultA: #AAAABA;
-	--defaultB: #BBBBCB;
-	--defaultC: #CCCCDC;
-	--defaultD: #DDDDED;
-	--defaultE: #EEEEFE;
-
-	--default1Muted: #111121;
-	--default2Muted: #222232;
-	--default3Muted: #333343;
-	--default4Muted: #444454;
-	--default5Muted: #555565;
-	--default6Muted: #666676;
-	--default7Muted: #777787;
-	--default8Muted: #888898;
-	--default9Muted: #9999A9;
-	--defaultAMuted: #AAAABA;
-	--defaultBMuted: #BBBBCB;
-	--defaultCMuted: #CCCCDC;
-	--defaultDMuted: #DDDDED;
-	--defaultEMuted: #EEEEFE;
-
-	--default1Transparent: rgba(17, 17, 33, 0.5);
-	--default2Transparent: rgba(34, 34, 50, 0.5);
-	--default3Transparent: rgba(51, 51, 67, 0.5);
-	--default4Transparent: rgba(68, 68, 84, 0.5);
-	--default5Transparent: rgba(85, 85, 101, 0.5);
-	--default6Transparent: rgba(102, 102, 118, 0.5);
-	--default7Transparent: rgba(119, 119, 135, 0.5);
-	--default8Transparent: rgba(136, 136, 152, 0.5);
-	--default9Transparent: rgba(153, 153, 169, 0.5);
-	--defaultATransparent: rgba(170, 170, 186, 0.5);
-	--defaultBTransparent: rgba(187, 187, 203, 0.5);
-	--defaultCTransparent: rgba(204, 204, 220, 0.5);
-	--defaultDTransparent: rgba(221, 221, 237, 0.5);
-	--defaultETransparent: rgba(238, 238, 254, 0.5);
-
-	/* Primary Color: Red-Orange (Hue 10, Sat 100) */
-	--primary1: #112111;
-	--primary2: #193019;
-	--primary3: #224222;
-	--primary4: #2A512A;
-	--primary5: #336333;
-	--primary6: #3C753C;
-	--primary7: #448444;
-	--primary8: #4E964E;
-	--primary9: #57A857;
-	--primaryA: #5FB75F;
-	--primaryB: #68C968;
-	--primaryC: #72DB72;
-	--primaryD: #79EA79;
-	--primaryE: #83FC83;
-
-	--primary1Muted: #112111;
-	--primary2Muted: #223222;
-	--primary3Muted: #334333;
-	--primary4Muted: #445444;
-	--primary5Muted: #556555;
-	--primary6Muted: #667666;
-	--primary7Muted: #778777;
-	--primary8Muted: #889888;
-	--primary9Muted: #99a999;
-	--primaryAMuted: #aabaaa;
-	--primaryBMuted: #bbcbbb;
-	--primaryCMuted: #ccdccc;
-	--primaryDMuted: #ddeddd;
-	--primaryEMuted: #eefeee;
-
-	--primary1Transparent: rgba(17, 33, 17, 0.5);
-	--primary2Transparent: rgba(25, 48, 25, 0.5);
-	--primary3Transparent: rgba(34, 66, 34, 0.5);
-	--primary4Transparent: rgba(42, 81, 42, 0.5);
-	--primary5Transparent: rgba(51, 99, 51, 0.5);
-	--primary6Transparent: rgba(60, 117, 60, 0.5);
-	--primary7Transparent: rgba(68, 132, 68, 0.5);
-	--primary8Transparent: rgba(78, 150, 78, 0.5);
-	--primary9Transparent: rgba(87, 168, 87, 0.5);
-	--primaryATransparent: rgba(95, 183, 95, 0.5);
-	--primaryBTransparent: rgba(104, 201, 104, 0.5);
-	--primaryCTransparent: rgba(114, 219, 114, 0.5);
-	--primaryDTransparent: rgba(121, 234, 121, 0.5);
-	--primaryETransparent: rgba(131, 252, 131, 0.5);
-
-	/* Accent Color: Teal (Hue 186) */
-	--accent1: #112121;
-	--accent2: #223232;
-	--accent3: #334343;
-	--accent4: #445454;
-	--accent5: #556565;
-	--accent6: #667676;
-	--accent7: #778787;
-	--accent8: #889898;
-	--accent9: #99a9a9;
-	--accentA: #aababa;
-	--accentB: #bbcbcb;
-	--accentC: #ccdcdc;
-	--accentD: #ddeded;
-	--accentE: #eefefe;
-
-	--accent1Muted: #112121;
-	--accent2Muted: #223232;
-	--accent3Muted: #334343;
-	--accent4Muted: #445454;
-	--accent5Muted: #556565;
-	--accent6Muted: #667676;
-	--accent7Muted: #778787;
-	--accent8Muted: #889898;
-	--accent9Muted: #99a9a9;
-	--accentAMuted: #aababa;
-	--accentBMuted: #bbcbcb;
-	--accentCMuted: #ccdcdc;
-	--accentDMuted: #ddeded;
-	--accentEMuted: #eefefe;
-
-	--accent1Transparent: rgba(17, 33, 33, 0.5);
-	--accent2Transparent: rgba(34, 50, 50, 0.5);
-	--accent3Transparent: rgba(51, 67, 67, 0.5);
-	--accent4Transparent: rgba(68, 84, 84, 0.5);
-	--accent5Transparent: rgba(85, 101, 101, 0.5);
-	--accent6Transparent: rgba(102, 118, 118, 0.5);
-	--accent7Transparent: rgba(119, 135, 135, 0.5);
-	--accent8Transparent: rgba(136, 152, 152, 0.5);
-	--accent9Transparent: rgba(153, 169, 169, 0.5);
-	--accentATransparent: rgba(170, 186, 186, 0.5);
-	--accentBTransparent: rgba(187, 203, 201, 0.5);
-	--accentCTransparent: rgba(204, 220, 220, 0.5);
-	--accentDTransparent: rgba(221, 237, 237, 0.5);
-	--accentETransparent: rgba(238, 254, 254, 0.5);
-
-	/* Specialty Colors */
-	--midPrimaryAccentA: #85B98D; /* Used for h3 */
-	--midPrimaryAccent8: #6B9773; /* Used for h3 small */
-	--midDefaultAccentA: #AAB2BA; /* Used for h5 */
-	--midDefaultAccent8: #889098; /* Used for h5 small */
-	--defaultAFullTransparent: rgba(170, 170, 186, 0); /* Used for row border groups */
-	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+.user-css-presentation .panel-danger {
+    background-color: var(--danger3Transparent);
+    border-color: var(--dangerDTransparent);
+    color: var(--dangerDMuted);
+    box-shadow: 0 0 2px 2px var(--dangerDTransparent);
 }
 
-/* Color Theme: Arshan */
-.user-css-presentation .arshan, .user-css-presentation .tag-theme-arshan, .user-css-presentation .category-3eabf245-4dc1-42bc-ac01-d1c4a7988d2e, .user-css-presentation .category-ddc22845-e8f3-401f-9c59-c9a390bf619e {
-	/* Default Color: Muted Blue (Hue 65) */
-	--default1: #111111;
-	--default2: #222222;
-	--default3: #333333;
-	--default4: #444444;
-	--default5: #555555;
-	--default6: #666666;
-	--default7: #777777;
-	--default8: #888888;
-	--default9: #999999;
-	--defaultA: #AAAAAA;
-	--defaultB: #BBBBBB;
-	--defaultC: #CCCCCC;
-	--defaultD: #DDDDDD;
-	--defaultE: #EEEEEE;
-
-	--default1Muted: #111111;
-	--default2Muted: #222222;
-	--default3Muted: #333333;
-	--default4Muted: #444444;
-	--default5Muted: #555555;
-	--default6Muted: #666666;
-	--default7Muted: #777777;
-	--default8Muted: #888888;
-	--default9Muted: #999999;
-	--defaultAMuted: #AAAAAA;
-	--defaultBMuted: #BBBBBB;
-	--defaultCMuted: #CCCCCC;
-	--defaultDMuted: #DDDDDD;
-	--defaultEMuted: #EEEEEE;
-
-	--default1Transparent: rgba(17, 17, 17, 0.5);
-	--default2Transparent: rgba(34, 34, 34, 0.5);
-	--default3Transparent: rgba(51, 51, 51, 0.5);
-	--default4Transparent: rgba(68, 68, 68, 0.5);
-	--default5Transparent: rgba(85, 85, 85, 0.5);
-	--default6Transparent: rgba(102, 102, 102, 0.5);
-	--default7Transparent: rgba(119, 119, 119, 0.5);
-	--default8Transparent: rgba(136, 136, 136, 0.5);
-	--default9Transparent: rgba(153, 153, 153, 0.5);
-	--defaultATransparent: rgba(170, 170, 170, 0.5);
-	--defaultBTransparent: rgba(187, 187, 187, 0.5);
-	--defaultCTransparent: rgba(204, 204, 204, 0.5);
-	--defaultDTransparent: rgba(221, 221, 221, 0.5);
-	--defaultETransparent: rgba(238, 238, 238, 0.5);
-
-	/* Primary Color: Red-Orange (Hue 10, Sat 100) */
-	--primary1: #1E0C00;
-	--primary2: #2D1300;
-	--primary3: #3F1800;
-	--primary4: #4F1E00;
-	--primary5: #602600;
-	--primary6: #722B00;
-	--primary7: #822D00;
-	--primary8: #933B00;
-	--primary9: #A54200;
-	--primaryA: #B54800;
-	--primaryB: #C64500;
-	--primaryC: #D85D00;
-	--primaryD: #E86000;
-	--primaryE: #F95F00;
-
-	--primary1Muted: #1E150F;
-	--primary2Muted: #302720;
-	--primary3Muted: #423933;
-	--primary4Muted: #514842;
-	--primary5Muted: #635A54;
-	--primary6Muted: #756C66;
-	--primary7Muted: #847B76;
-	--primary8Muted: #968D87;
-	--primary9Muted: #A89F99;
-	--primaryAMuted: #B7AEA8;
-	--primaryBMuted: #C9C0BB;
-	--primaryCMuted: #DBD2CB;
-	--primaryDMuted: #EAE2DC;
-	--primaryEMuted: #FCF3ED;
-
-	--primary1Transparent: rgba(30, 12, 0, 0.5);
-	--primary2Transparent: rgba(45, 19, 0, 0.5);
-	--primary3Transparent: rgba(63, 24, 0, 0.5);
-	--primary4Transparent: rgba(79, 30, 0, 0.5);
-	--primary5Transparent: rgba(96, 38, 0, 0.5);
-	--primary6Transparent: rgba(114, 43, 0, 0.5);
-	--primary7Transparent: rgba(130, 45, 0, 0.5);
-	--primary8Transparent: rgba(147, 59, 0, 0.5);
-	--primary9Transparent: rgba(165, 66, 0, 0.5);
-	--primaryATransparent: rgba(181, 72, 0, 0.5);
-	--primaryBTransparent: rgba(198, 69, 0, 0.5);
-	--primaryCTransparent: rgba(216, 93, 0, 0.5);
-	--primaryDTransparent: rgba(232, 96, 0, 0.5);
-	--primaryETransparent: rgba(249, 95, 0, 0.5);
-
-	/* Accent Color: Teal (Hue 186) */
-	--accent1: #1E150F;
-	--accent2: #302720;
-	--accent3: #423933;
-	--accent4: #514842;
-	--accent5: #635A54;
-	--accent6: #756C66;
-	--accent7: #847B76;
-	--accent8: #968D87;
-	--accent9: #A89F99;
-	--accentA: #B7AEA8;
-	--accentB: #C9C0BB;
-	--accentC: #DBD2CB;
-	--accentD: #EAE2DC;
-	--accentE: #FCF3ED;
-
-	--accent1Muted: #1E150F;
-	--accent2Muted: #302720;
-	--accent3Muted: #423933;
-	--accent4Muted: #514842;
-	--accent5Muted: #635A54;
-	--accent6Muted: #756C66;
-	--accent7Muted: #847B76;
-	--accent8Muted: #968D87;
-	--accent9Muted: #A89F99;
-	--accentAMuted: #B7AEA8;
-	--accentBMuted: #C9C0BB;
-	--accentCMuted: #DBD2CB;
-	--accentDMuted: #EAE2DC;
-	--accentEMuted: #FCF3ED;
-
-	--accent1Transparent: rgba(30, 21, 15, 0.5);
-	--accent2Transparent: rgba(40, 39, 32, 0.5);
-	--accent3Transparent: rgba(66, 57, 51, 0.5);
-	--accent4Transparent: rgba(81, 72, 66, 0.5);
-	--accent5Transparent: rgba(99, 90, 84, 0.5);
-	--accent6Transparent: rgba(117, 108, 102, 0.5);
-	--accent7Transparent: rgba(132, 123, 118, 0.5);
-	--accent8Transparent: rgba(150, 141, 135, 0.5);
-	--accent9Transparent: rgba(168, 159, 153, 0.5);
-	--accentATransparent: rgba(183, 174, 168, 0.5);
-	--accentBTransparent: rgba(201, 192, 187, 0.5);
-	--accentCTransparent: rgba(219, 210, 203, 0.5);
-	--accentDTransparent: rgba(234, 226, 220, 0.5);
-	--accentETransparent: rgba(252, 243, 237, 0.5);
-
-	/* Specialty Colors */
-	--midPrimaryAccentA: #C98456; /* Used for h3 */
-	--midPrimaryAccent8: #966544; /* Used for h3 small */
-	--midDefaultAccentA: #C9C0BA; /* Used for h5 */
-	--midDefaultAccent8: #96928F; /* Used for h5 small */
-	--defaultAFullTransparent: rgba(170, 170, 186, 0); /* Used for row border groups */
-	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+.user-css-presentation .panel-danger hr {
+    border-color: var(--dangerA);
 }
 
-/* Color Theme: Drakari */
-.user-css-presentation .drakari, .user-css-presentation .tag-theme-drakari, .user-css-presentation .category-ea4be012-9100-4767-85ab-be1e9f3ad706, .user-css-presentation .category-3bf6bdc2-817f-4056-be26-e358879cdc5d {
-	/* Default Color: Muted rED (Hue 0) */
-	--default1: #211111;
-	--default2: #322222;
-	--default3: #433333;
-	--default4: #544444;
-	--default5: #655555;
-	--default6: #766666;
-	--default7: #877777;
-	--default8: #988888;
-	--default9: #A99999;
-	--defaultA: #BAAAAA;
-	--defaultB: #CBBBBB;
-	--defaultC: #DCCCCC;
-	--defaultD: #EDDDDD;
-	--defaultE: #FEEEEE;
-
-	--default1Muted: #211111;
-	--default2Muted: #322222;
-	--default3Muted: #433333;
-	--default4Muted: #544444;
-	--default5Muted: #655555;
-	--default6Muted: #766666;
-	--default7Muted: #877777;
-	--default8Muted: #988888;
-	--default9Muted: #A99999;
-	--defaultAMuted: #BAAAAA;
-	--defaultBMuted: #CBBBBB;
-	--defaultCMuted: #DCCCCC;
-	--defaultDMuted: #EDDDDD;
-	--defaultEMuted: #FEEEEE;
-
-	--default1Transparent: rgba(33, 17, 17, 0.5);
-	--default2Transparent: rgba(50, 34, 34, 0.5);
-	--default3Transparent: rgba(67, 51, 51, 0.5);
-	--default4Transparent: rgba(84, 68, 68, 0.5);
-	--default5Transparent: rgba(101, 85, 85, 0.5);
-	--default6Transparent: rgba(118, 102, 102, 0.5);
-	--default7Transparent: rgba(135, 119, 119, 0.5);
-	--default8Transparent: rgba(152, 136, 136, 0.5);
-	--default9Transparent: rgba(169, 153, 153, 0.5);
-	--defaultATransparent: rgba(186, 170, 170, 0.5);
-	--defaultBTransparent: rgba(203, 187, 187, 0.5);
-	--defaultCTransparent: rgba(220, 204, 204, 0.5);
-	--defaultDTransparent: rgba(237, 221, 221, 0.5);
-	--defaultETransparent: rgba(254, 238, 238, 0.5);
-
-	/* Primary Color: Purple->Yellow */
-	--primary1: #1A031C;
-	--primary2: #2B052D;
-	--primary3: #3F0A36;
-	--primary4: #4F0F3B;
-	--primary5: #60173D;
-	--primary6: #721E3F;
-	--primary7: #82293C;
-	--primary8: #93353D;
-	--primary9: #A54F45;
-	--primaryA: #B5674D;
-	--primaryB: #C68A5F;
-	--primaryC: #D8AD70;
-	--primaryD: #E8CE81;
-	--primaryE: #F9EF95;
-
-	--primary1Muted: #1C0E1C;
-	--primary2Muted: #2D212B;
-	--primary3Muted: #3F313C;
-	--primary4Muted: #4F4149;
-	--primary5Muted: #605358;
-	--primary6Muted: #726468;
-	--primary7Muted: #827376;
-	--primary8Muted: #938586;
-	--primary9Muted: #A59998;
-	--primaryAMuted: #B5ABA8;
-	--primaryBMuted: #C6BFBA;
-	--primaryCMuted: #D8D3CD;
-	--primaryDMuted: #E8E5DC;
-	--primaryEMuted: #F9F8EF;
-
-	--primary1Transparent: rgba(36, 3, 28, 0.5);
-	--primary2Transparent: rgba(43, 5, 45, 0.5);
-	--primary3Transparent: rgba(63, 10, 54, 0.5);
-	--primary4Transparent: rgba(79, 15, 59, 0.5);
-	--primary5Transparent: rgba(96, 23, 61, 0.5);
-	--primary6Transparent: rgba(114, 30, 61, 0.5);
-	--primary7Transparent: rgba(130, 41, 60, 0.5);
-	--primary8Transparent: rgba(147, 53, 61, 0.5);
-	--primary9Transparent: rgba(165, 79, 69, 0.5);
-	--primaryATransparent: rgba(181, 103, 77, 0.5);
-	--primaryBTransparent: rgba(198, 138, 95, 0.5);
-	--primaryCTransparent: rgba(216, 173, 112, 0.5);
-	--primaryDTransparent: rgba(232, 206, 129, 0.5);
-	--primaryETransparent: rgba(249, 239, 149, 0.5);
-
-	/* Accent Color: Purple->Yellow */
-	--accent1: #1C0110;
-	--accent2: #2D011A;
-	--accent3: #3F0A1C;
-	--accent4: #4F0E21;
-	--accent5: #601824;
-	--accent6: #722527;
-	--accent7: #823B34;
-	--accent8: #935945;
-	--accent9: #A5765B;
-	--accentA: #B59572;
-	--accentB: #C6B08B;
-	--accentC: #D8CDA9;
-	--accentD: #E8E2C7;
-	--accentE: #F9F9E8;
-
-	--accent1Muted: #1C0D17;
-	--accent2Muted: #2D2127;
-	--accent3Muted: #3F3538;
-	--accent4Muted: #4F4446;
-	--accent5Muted: #605859;
-	--accent6Muted: #726868;
-	--accent7Muted: #827977;
-	--accent8Muted: #938A88;
-	--accent9Muted: #A59D9A;
-	--accentAMuted: #B5AEA8;
-	--accentBMuted: #C6C1BA;
-	--accentCMuted: #D8D6CD;
-	--accentDMuted: #E8E6DC;
-	--accentEMuted: #F9F9ED;
-
-	--accent1Transparent: rgba(28, 1, 16, 0.5);
-	--accent2Transparent: rgba(45, 1, 26, 0.5);
-	--accent3Transparent: rgba(63, 10, 28, 0.5);
-	--accent4Transparent: rgba(79, 14, 33, 0.5);
-	--accent5Transparent: rgba(96, 24, 36, 0.5);
-	--accent6Transparent: rgba(114, 37, 39, 0.5);
-	--accent7Transparent: rgba(130, 59, 52, 0.5);
-	--accent8Transparent: rgba(147, 89, 69, 0.5);
-	--accent9Transparent: rgba(165, 118, 91, 0.5);
-	--accentATransparent: rgba(181, 149, 114, 0.5);
-	--accentBTransparent: rgba(198, 176, 139, 0.5);
-	--accentCTransparent: rgba(216, 205, 169, 0.5);
-	--accentDTransparent: rgba(232, 223, 199, 0.5);
-	--accentETransparent: rgba(249, 249, 232, 0.5);
-
-	/* Specialty Colors */
-	--midPrimaryAccentA: #B57E60; /* Used for h3 */
-	--midPrimaryAccent8: #934741; /* Used for h3 small */
-	--midDefaultAccentA: #B8A08E; /* Used for h5 */
-	--midDefaultAccent8: #967167; /* Used for h5 small */
-	--defaultAFullTransparent: rgba(186, 170, 170, 0); /* Used for row border groups */
-	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+.user-css-presentation .panel-danger .panel-heading {
+    background-color: var(--dangerDTransparent);
 }
 
-/* Color Theme: Solus */
-.user-css-presentation .solus, .user-css-presentation .tag-theme-solus, .user-css-presentation .category-1eb3624c-9c1c-4c81-aaa2-144280de91b0, .user-css-presentation .category-66c5e6cd-d242-4156-aed4-18f0a3183e2f {
-	/* Default Color: Muted Blue-Green */
-	--default1: #0F191E;
-	--default2: #202B30;
-	--default3: #333D42;
-	--default4: #424C51;
-	--default5: #545E63;
-	--default6: #667075;
-	--default7: #767F84;
-	--default8: #879196;
-	--default9: #99A3A8;
-	--defaultA: #A8B2B7;
-	--defaultB: #BBC4C9;
-	--defaultC: #CBD6DB;
-	--defaultD: #DCE5EA;
-	--defaultE: #EDF7FC;
-
-	--default1Muted: #0F191E;
-	--default2Muted: #202B30;
-	--default3Muted: #333D42;
-	--default4Muted: #424C51;
-	--default5Muted: #545E63;
-	--default6Muted: #667075;
-	--default7Muted: #767F84;
-	--default8Muted: #879196;
-	--default9Muted: #99A3A8;
-	--defaultAMuted: #A8B2B7;
-	--defaultBMuted: #BBC4C9;
-	--defaultCMuted: #CBD6DB;
-	--defaultDMuted: #DCE5EA;
-	--defaultEMuted: #EDF7FC;
-
-	--default1Transparent: rgba(15, 25, 30, 0.5);
-	--default2Transparent: rgba(32, 43, 48, 0.5);
-	--default3Transparent: rgba(51, 61, 66, 0.5);
-	--default4Transparent: rgba(66, 76, 81, 0.5);
-	--default5Transparent: rgba(84, 94, 99, 0.5);
-	--default6Transparent: rgba(102, 112, 117, 0.5);
-	--default7Transparent: rgba(118, 127, 132, 0.5);
-	--default8Transparent: rgba(135, 145, 150, 0.5);
-	--default9Transparent: rgba(153, 163, 168, 0.5);
-	--defaultATransparent: rgba(168, 178, 183, 0.5);
-	--defaultBTransparent: rgba(187, 196, 201, 0.5);
-	--defaultCTransparent: rgba(203, 214, 219, 0.5);
-	--defaultDTransparent: rgba(220, 229, 234, 0.5);
-	--defaultETransparent: rgba(237, 247, 252, 0.5);
-
-	/* Primary Color: Yellow */
-	--primary1: #1E0800;
-	--primary2: #300C00;
-	--primary3: #421600;
-	--primary4: #512101;
-	--primary5: #632D01;
-	--primary6: #753E03;
-	--primary7: #844F05;
-	--primary8: #966306;
-	--primary9: #A87A08;
-	--primaryA: #B7920B;
-	--primaryB: #C9AD0C;
-	--primaryC: #DBCA0F;
-	--primaryD: #EAEA10;
-	--primaryE: #FCFC11;
-
-	--primary1Muted: #1C120E;
-	--primary2Muted: #2D221F;
-	--primary3Muted: #3F3531;
-	--primary4Muted: #4F4640;
-	--primary5Muted: #605852;
-	--primary6Muted: #726B63;
-	--primary7Muted: #827B73;
-	--primary8Muted: #938E85;
-	--primary9Muted: #A5A196;
-	--primaryAMuted: #B5B1A6;
-	--primaryBMuted: #C6C4B8;
-	--primaryCMuted: #D8D7C9;
-	--primaryDMuted: #E8E8DA;
-	--primaryEMuted: #F9F9EA;
-
-	--primary1Transparent: rgba(30, 8, 0, 0.5);
-	--primary2Transparent: rgba(48, 12, 0, 0.5);
-	--primary3Transparent: rgba(66, 22, 0, 0.5);
-	--primary4Transparent: rgba(81, 33, 1, 0.5);
-	--primary5Transparent: rgba(99, 45, 1, 0.5);
-	--primary6Transparent: rgba(117, 62, 3, 0.5);
-	--primary7Transparent: rgba(132, 79, 5, 0.5);
-	--primary8Transparent: rgba(150, 99, 6, 0.5);
-	--primary9Transparent: rgba(168, 122, 8, 0.5);
-	--primaryATransparent: rgba(183, 146, 11, 0.5);
-	--primaryBTransparent: rgba(207, 173, 12, 0.5);
-	--primaryCTransparent: rgba(219, 202, 15, 0.5);
-	--primaryDTransparent: rgba(234, 234, 16, 0.5);
-	--primaryETransparent: rgba(252, 252, 17, 0.5);
-
-	/* Accent Color: Muted Green */
-	--accent1: #141E0F;
-	--accent2: #263020;
-	--accent3: #384233;
-	--accent4: #475142;
-	--accent5: #596354;
-	--accent6: #6B7566;
-	--accent7: #7A8476;
-	--accent8: #8C9687;
-	--accent9: #9EA899;
-	--accentA: #ADB7A8;
-	--accentB: #C0C9BB;
-	--accentC: #D1DBCB;
-	--accentD: #E1EADC;
-	--accentE: #F2FCED;
-
-	--accent1Muted: #141E0F;
-	--accent2Muted: #263020;
-	--accent3Muted: #384233;
-	--accent4Muted: #475142;
-	--accent5Muted: #596354;
-	--accent6Muted: #6B7566;
-	--accent7Muted: #7A8476;
-	--accent8Muted: #8C9687;
-	--accent9Muted: #9EA899;
-	--accentAMuted: #ADB7A8;
-	--accentBMuted: #C0C9BB;
-	--accentCMuted: #D1DBCB;
-	--accentDMuted: #E1EADC;
-	--accentEMuted: #F2FCED;
-
-	--accent1Transparent: rgba(20, 30, 15, 0.5);
-	--accent2Transparent: rgba(38, 48, 32, 0.5);
-	--accent3Transparent: rgba(56, 66, 51, 0.5);
-	--accent4Transparent: rgba(71, 81, 66, 0.5);
-	--accent5Transparent: rgba(89, 99, 84, 0.5);
-	--accent6Transparent: rgba(107, 117, 102, 0.5);
-	--accent7Transparent: rgba(122, 132, 118, 0.5);
-	--accent8Transparent: rgba(140, 150, 135, 0.5);
-	--accent9Transparent: rgba(158, 168, 153, 0.5);
-	--accentATransparent: rgba(173, 183, 168, 0.5);
-	--accentBTransparent: rgba(192, 201, 187, 0.5);
-	--accentCTransparent: rgba(209, 219, 203, 0.5);
-	--accentDTransparent: rgba(225, 235, 220, 0.5);
-	--accentETransparent: rgba(242, 252, 237, 0.5);
-
-	/* Specialty Colors */
-	--midPrimaryAccentA: #B2A55A; /* Used for h3 */
-	--midPrimaryAccent8: #917D47; /* Used for h3 small */
-	--midDefaultAccentA: #ABB5B0; /* Used for h5 */
-	--midDefaultAccent8: #8A948F; /* Used for h5 small */
-	--defaultAFullTransparent: rgba(186, 170, 170, 0); /* Used for row border groups */
-	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+.user-css-presentation .panel-danger .panel-heading h3 {
+    color: var(--dangerDMuted);
 }
 
-/* Color Theme: Terran */
-.user-css-presentation .terran, .user-css-presentation .tag-theme-terran, .user-css-presentation .category-f680cb8b-4874-4152-806a-35d2b42c6c0b, .user-css-presentation .category-5162d4c3-0773-4b70-b1aa-dc2d9d495d27 {
-	/* Default Color: Green-Yellow */
-	--default1: #151C07;
-	--default2: #232E0D;
-	--default3: #303F13;
-	--default4: #3E5017;
-	--default5: #4C601A;
-	--default6: #5C711D;
-	--default7: #6C8220;
-	--default8: #839523;
-	--default9: #99A826;
-	--defaultA: #ACB727;
-	--defaultB: #BEC627;
-	--defaultC: #CED72B;
-	--defaultD: #DEE82E;
-	--defaultE: #EBF430;
-
-	--default1Muted: #15190C;
-	--default2Muted: #292D1E;
-	--default3Muted: #383D2F;
-	--default4Muted: #4A4F40;
-	--default5Muted: #5A5E50;
-	--default6Muted: #6C7062;
-	--default7Muted: #7C7F72;
-	--default8Muted: #919385;
-	--default9Muted: #A4A598;
-	--defaultAMuted: #B4B5A6;
-	--defaultBMuted: #C3C4B8;
-	--defaultCMuted: #D5D6C7;
-	--defaultDMuted: #E4E5DA;
-	--defaultEMuted: #F1F2E6;
-
-	--default1Transparent: rgba(21, 28, 7, 0.5);
-	--default2Transparent: rgba(35, 46, 13, 0.5);
-	--default3Transparent: rgba(48, 63, 19, 0.5);
-	--default4Transparent: rgba(62, 80, 23, 0.5);
-	--default5Transparent: rgba(76, 96, 26, 0.5);
-	--default6Transparent: rgba(92, 113, 29, 0.5);
-	--default7Transparent: rgba(108, 130, 32, 0.5);
-	--default8Transparent: rgba(131, 149, 35, 0.5);
-	--default9Transparent: rgba(153, 168, 38, 0.5);
-	--defaultATransparent: rgba(172, 183, 39, 0.5);
-	--defaultBTransparent: rgba(190, 198, 39, 0.5);
-	--defaultCTransparent: rgba(206, 215, 43, 0.5);
-	--defaultDTransparent: rgba(222, 232, 46, 0.5);
-	--defaultETransparent: rgba(235, 244, 48, 0.5);
-
-	/* Primary Color: Cyan */
-	--primary1: #020819;
-	--primary2: #05132B;
-	--primary3: #081D3D;
-	--primary4: #0E2C4E;
-	--primary5: #133B5E;
-	--primary6: #1B4E6F;
-	--primary7: #22607F;
-	--primary8: #2C7992;
-	--primary9: #3691A5;
-	--primaryA: #41A8B5;
-	--primaryB: #4CBEC4;
-	--primaryC: #5AD2CF;
-	--primaryD: #67E5DA;
-	--primaryE: #6DF2E9;
-
-	--primary1Muted: #0B0E16;
-	--primary2Muted: #1B2028;
-	--primary3Muted: #2D323A;
-	--primary4Muted: #3E454C;
-	--primary5Muted: #4E555B;
-	--primary6Muted: #60686D;
-	--primary7Muted: #70787C;
-	--primary8Muted: #848E91;
-	--primary9Muted: #97A1A3;
-	--primaryAMuted: #A4B1B2;
-	--primaryBMuted: #B6C1C1;
-	--primaryCMuted: #C2D1D0;
-	--primaryDMuted: #D9E2E2;
-	--primaryEMuted: #E6EFEE;
-
-	--primary1Transparent: rgba(2, 8, 25, 0.5);
-	--primary2Transparent: rgba(5, 19, 49, 0.5);
-	--primary3Transparent: rgba(8, 29, 61, 0.5);
-	--primary4Transparent: rgba(14, 44, 78, 0.5);
-	--primary5Transparent: rgba(19, 59, 94, 0.5);
-	--primary6Transparent: rgba(27, 78, 111, 0.5);
-	--primary7Transparent: rgba(34, 96, 127, 0.5);
-	--primary8Transparent: rgba(44, 121, 146, 0.5);
-	--primary9Transparent: rgba(54, 145, 165, 0.5);
-	--primaryATransparent: rgba(65, 168, 181, 0.5);
-	--primaryBTransparent: rgba(76, 190, 196, 0.5);
-	--primaryCTransparent: rgba(91, 210, 207, 0.5);
-	--primaryDTransparent: rgba(103, 229, 218, 0.5);
-	--primaryETransparent: rgba(109, 242, 233, 0.5);
-
-	/* Accent Color: Moss Green */
-	--accent1: #041910;
-	--accent2: #0A2B17;
-	--accent3: #103D1E;
-	--accent4: #194C21;
-	--accent5: #225B23;
-	--accent6: #336C2E;
-	--accent7: #447C39;
-	--accent8: #5F904A;
-	--accent9: #79A35B;
-	--accentA: #92B26D;
-	--accentB: #AAC17F;
-	--accentC: #C2D383;
-	--accentD: #DAE587;
-	--accentE: #ECF4BA;
-
-	--accent1Muted: #0B1611;
-	--accent2Muted: #1B2820;
-	--accent3Muted: #2D3A31;
-	--accent4Muted: #3C493E;
-	--accent5Muted: #4C594C;
-	--accent6Muted: #606B5F;
-	--accent7Muted: #717A6F;
-	--accent8Muted: #858E81;
-	--accent9Muted: #9AA095;
-	--accentAMuted: #AAAFA3;
-	--accentBMuted: #BCBFB5;
-	--accentCMuted: #D2D6C7;
-	--accentDMuted: #ECEDE6;
-	--accentEMuted: #F1F2EA;
-
-	--accent1Transparent: rgba(4, 25, 16, 0.5);
-	--accent2Transparent: rgba(10, 43, 23, 0.5);
-	--accent3Transparent: rgba(16, 61, 30, 0.5);
-	--accent4Transparent: rgba(25, 76, 33, 0.5);
-	--accent5Transparent: rgba(34, 91, 35, 0.5);
-	--accent6Transparent: rgba(51, 108, 46, 0.5);
-	--accent7Transparent: rgba(64, 124, 57, 0.5);
-	--accent8Transparent: rgba(95, 144, 74, 0.5);
-	--accent9Transparent: rgba(121, 163, 91, 0.5);
-	--accentATransparent: rgba(146, 178, 109, 0.5);
-	--accentBTransparent: rgba(170, 193, 127, 0.5);
-	--accentCTransparent: rgba(194, 211, 131, 0.5);
-	--accentDTransparent: rgba(218, 229, 135, 0.5);
-	--accentETransparent: rgba(236, 244, 186, 0.5);
-
-	/* Specialty Colors */
-	--midPrimaryAccentA: #6AAD91; /* Used for h3 */
-	--midPrimaryAccent8: #46856E; /* Used for h3 small */
-	--midDefaultAccentA: #9FB54A; /* Used for h5 */
-	--midDefaultAccent8: #719337; /* Used for h5 small */
-	--defaultAFullTransparent: rgba(172, 183, 39, 0); /* Used for row border groups */
-	--default3MutedTransparent: rgba(56, 61, 47, 0.5); /* Used for body background */
+.user-css-presentation .panel-danger .panel-heading small {
+    color: var(--dangerCMuted);
 }
 
-.user-css-presentation .sionian, .user-css-presentation .tag-theme-sionian, .user-css-presentation .category-723c6440-ca73-4e61-b35c-9d66dd1a27d0, .user-css-presentation .category-264de840-9175-4c60-935f-ff5ce2eeb023 {
-	/* Default Color: Muted Tan */
-	--default1: #1E0F01;
-	--default2: #302011;
-	--default3: #423323;
-	--default4: #514232;
-	--default5: #635445;
-	--default6: #756656;
-	--default7: #847667;
-	--default8: #968778;
-	--default9: #A8998A;
-	--defaultA: #B7A89A;
-	--defaultB: #C9BBAD;
-	--defaultC: #DBCBBC;
-	--defaultD: #EADCCE;
-	--defaultE: #FCEDDE;
+.user-css-presentation .panel-warning {
+    background-color: var(--warning3Transparent);
+    border-color: var(--warningDTransparent);
+    color: var(--warningDMuted);
+    box-shadow: 0 0 2px 2px var(--warningDTransparent);
+}
 
-	--default1Muted: #1E0F01;
-	--default2Muted: #302011;
-	--default3Muted: #423323;
-	--default4Muted: #514232;
-	--default5Muted: #635445;
-	--default6Muted: #756656;
-	--default7Muted: #847667;
-	--default8Muted: #968778;
-	--default9Muted: #A8998A;
-	--defaultAMuted: #B7A89A;
-	--defaultBMuted: #C9BBAD;
-	--defaultCMuted: #DBCBBC;
-	--defaultDMuted: #EADCCE;
-	--defaultEMuted: #FCEDDE;
+.user-css-presentation .panel-warning hr {
+    border-color: var(--warningA);
+}
 
-	--default1Transparent: rgba(30, 15, 1, 0.5);
-	--default2Transparent: rgba(48, 32, 17, 0.5);
-	--default3Transparent: rgba(66, 51, 35, 0.5);
-	--default4Transparent: rgba(81, 66, 50, 0.5);
-	--default5Transparent: rgba(99, 84, 69, 0.5);
-	--default6Transparent: rgba(117, 112, 86, 0.5);
-	--default7Transparent: rgba(132, 118, 103, 0.5);
-	--default8Transparent: rgba(150, 133, 120, 0.5);
-	--default9Transparent: rgba(168, 153, 138, 0.5);
-	--defaultATransparent: rgba(183, 168, 154, 0.5);
-	--defaultBTransparent: rgba(201, 187, 173, 0.5);
-	--defaultCTransparent: rgba(219, 203, 188, 0.5);
-	--defaultDTransparent: rgba(234, 220, 206, 0.5);
-	--defaultETransparent: rgba(252, 237, 222, 0.5);
+.user-css-presentation .panel-warning .panel-heading {
+    background-color: var(--warningDTransparent);
+}
 
-	/* Primary Color: Green */
-	--primary1: #071902;
-	--primary2: #0D2B07;
-	--primary3: #123D0B;
-	--primary4: #1A4E14;
-	--primary5: #215E1C;
-	--primary6: #2B6F28;
-	--primary7: #347F34;
-	--primary8: #449147;
-	--primary9: #53A359;
-	--primaryA: #67B46F;
-	--primaryB: #7BC484;
-	--primaryC: #91D59C;
-	--primaryD: #A7E5B3;
-	--primaryE: #B4F7C1;
+.user-css-presentation .panel-warning .panel-heading h3 {
+    color: var(--warningDMuted);
+}
 
-	--primary1Muted: #0E160B;
-	--primary2Muted: #1F281E;
-	--primary3Muted: #2F3A2D;
-	--primary4Muted: #434C42;
-	--primary5Muted: #505B4F;
-	--primary6Muted: #616D60;
-	--primary7Muted: #6F7C6F;
-	--primary8Muted: #818E82;
-	--primary9Muted: #95A096;
-	--primaryAMuted: #A6B2A7;
-	--primaryBMuted: #B6C1B7;
-	--primaryCMuted: #C9D3CA;
-	--primaryDMuted: #D7E2D9;
-	--primaryEMuted: #EBF4EC;
+.user-css-presentation .panel-warning .panel-heading small {
+    color: var(--warningCMuted);
+}
 
-	--primary1Transparent: rgba(7, 25, 2, 0.5);
-	--primary2Transparent: rgba(13, 43, 7, 0.5);
-	--primary3Transparent: rgba(18, 61, 11, 0.5);
-	--primary4Transparent: rgba(26, 78, 20, 0.5);
-	--primary5Transparent: rgba(33, 94, 28, 0.5);
-	--primary6Transparent: rgba(43, 111, 40, 0.5);
-	--primary7Transparent: rgba(52, 127, 52, 0.5);
-	--primary8Transparent: rgba(68, 145, 71, 0.5);
-	--primary9Transparent: rgba(83, 163, 89, 0.5);
-	--primaryATransparent: rgba(103, 180, 111, 0.5);
-	--primaryBTransparent: rgba(123, 196, 132, 0.5);
-	--primaryCTransparent: rgba(145, 213, 156, 0.5);
-	--primaryDTransparent: rgba(167, 229, 179, 0.5);
-	--primaryETransparent: rgba(180, 247, 193, 0.5);
+.user-css-presentation .panel-info {
+    background-color: var(--info3Transparent);
+    border-color: var(--infoDTransparent);
+    color: var(--infoDMuted);
+    box-shadow: 0 0 2px 2px var(--infoDTransparent);
+}
 
-	/* Accent Color: Orange */
-	--accent1: #160A00;
-	--accent2: #281502;
-	--accent3: #3A1F04;
-	--accent4: #4B2C09;
-	--accent5: #5B390D;
-	--accent6: #6C4913;
-	--accent7: #7C5818;
-	--accent8: #8E6920;
-	--accent9: #A07A28;
-	--accentA: #B18D31;
-	--accentB: #C19F3A;
-	--accentC: #D2B546;
-	--accentD: #E2CA51;
-	--accentE: #F4DA58;
+.user-css-presentation .panel-info hr {
+    border-color: var(--infoA);
+}
 
-	--accent1Muted: #140E0A;
-	--accent2Muted: #26211C;
-	--accent3Muted: #38312B;
-	--accent4Muted: #494540;
-	--accent5Muted: #59544D;
-	--accent6Muted: #6B665F;
-	--accent7Muted: #7A756E;
-	--accent8Muted: #8C877F;
-	--accent9Muted: #9E9B94;
-	--accentAMuted: #AFACA5;
-	--accentBMuted: #BFBCB5;
-	--accentCMuted: #D1CFC8;
-	--accentDMuted: #E0DED7;
-	--accentEMuted: #F2F0EA;
+.user-css-presentation .panel-info .panel-heading {
+    background-color: var(--infoDTransparent);
+}
 
-	--accent1Transparent: rgba(22, 10, 0, 0.5);
-	--accent2Transparent: rgba(40, 21, 2, 0.5);
-	--accent3Transparent: rgba(58, 31, 4, 0.5);
-	--accent4Transparent: rgba(75, 44, 9, 0.5);
-	--accent5Transparent: rgba(91, 57, 13, 0.5);
-	--accent6Transparent: rgba(108, 73, 19, 0.5);
-	--accent7Transparent: rgba(124, 88, 24, 0.5);
-	--accent8Transparent: rgba(142, 105, 32, 0.5);
-	--accent9Transparent: rgba(160, 122, 40, 0.5);
-	--accentATransparent: rgba(177, 141, 49, 0.5);
-	--accentBTransparent: rgba(193, 159, 58, 0.5);
-	--accentCTransparent: rgba(210, 181, 70, 0.5);
-	--accentDTransparent: rgba(226, 202, 81, 0.5);
-	--accentETransparent: rgba(244, 218, 88, 0.5);
+.user-css-presentation .panel-info .panel-heading h3 {
+    color: var(--infoDMuted);
+}
 
-	/* Specialty Colors */
-	--midPrimaryAccentA: #8CA150; /* Used for h3 */
-	--midPrimaryAccent8: #697D34; /* Used for h3 small */
-	--midDefaultAccentA: #B49B66; /* Used for h5 */
-	--midDefaultAccent8: #92784C; /* Used for h5 small */
-	--defaultAFullTransparent: rgba(172, 183, 39, 0); /* Used for row border groups */
-	--default3MutedTransparent: rgba(66, 51, 35, 0.5); /* Used for body background */
+.user-css-presentation .panel-info .panel-heading small {
+    color: var(--infoCMuted);
+}
+
+.user-css-presentation .panel-success {
+    background-color: var(--success3Transparent);
+    border-color: var(--successDTransparent);
+    color: var(--successDMuted);
+    box-shadow: 0 0 2px 2px var(--successDTransparent);
+}
+
+.user-css-presentation .panel-success hr {
+    border-color: var(--successA);
+}
+
+.user-css-presentation .panel-success .panel-heading {
+    background-color: var(--successDTransparent);
+}
+
+.user-css-presentation .panel-success .panel-heading h3 {
+    color: var(--successDMuted);
+}
+
+.user-css-presentation .panel-success .panel-heading small {
+    color: var(--successCMuted);
+}
+
+.user-css-presentation .pallete-block {
+    font-size: 75px;
+    line-height: 50px;
+    text-align: center;
+    padding-bottom: 25px;
+}
+
+.user-css-presentation .pallete-block span {
+    margin-right: -10px;
+}
+
+/* RPG System Colorsets */
+.user-css-presentation .panel-starfinder {
+    background-color: var(--info3Transparent);
+    border-color: var(--infoDTransparent);
+    color: var(--infoDMuted);
+    box-shadow: 0 0 2px 2px var(--infoDTransparent);
+}
+
+.user-css-presentation .panel-starfinder hr {
+    border-color: var(--infoA);
+}
+
+.user-css-presentation .panel-starfinder .panel-heading {
+    background-color: var(--infoDTransparent);
+}
+
+.user-css-presentation .panel-starfinder .panel-heading h3 {
+    color: var(--infoDMuted);
+}
+
+.user-css-presentation .panel-starfinder .panel-heading small {
+    color: var(--infoCMuted);
+}
+
+.user-css-presentation .panel-ethnislight {
+    background-color: var(--warning3Transparent);
+    border-color: var(--warningDTransparent);
+    color: var(--warningDMuted);
+    box-shadow: 0 0 2px 2px var(--warningDTransparent);
+}
+
+.user-css-presentation .panel-ethnislight hr {
+    border-color: var(--warningA);
+}
+
+.user-css-presentation .panel-ethnislight .panel-heading {
+    background-color: var(--warningDTransparent);
+}
+
+.user-css-presentation .panel-ethnislight .panel-heading h3 {
+    color: var(--warningDMuted);
+}
+
+.user-css-presentation .panel-ethnislight .panel-heading small {
+    color: var(--warningCMuted);
+}
+
+.user-css-presentation .statblock {
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
+}
+
+.user-css-presentation .rpg-ethnislight-block-sophont.col-md-6 {
+    width: initial;
+    float: initial;
+    position: initial;
+    min-height: initial;
 }

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1626,150 +1626,1017 @@
     color: #ca5555;
 }
 
-/* Color Theme: Default (WA public) */
-.user-css-presentation {
-    /* Default Color: Yellow-Green (Hue 65) */
-    --default1: #1D1E0F;
-    --default2: #2F3020;
-    --default3: #414233;
-    --default4: #505142;
-    --default5: #626354;
-    --default6: #747566;
-    --default7: #838476;
-    --default8: #959687;
-    --default9: #A7A899;
-    --defaultA: #B6B7A8;
-    --defaultB: #C8C9BB;
-    --defaultC: #DADBCB;
-    --defaultD: #E9EADC;
-    --defaultE: #FBFCED;
+/* PERSONAL TWEAKS */
+.user-css-presentation .article-block-hide-heading .article-panel .heading,
+.user-css-presentation .article-block-hide-subheading .article-panel .subheading,
+.user-css-presentation .article-block-hide-date .article-panel .date,
+.user-css-presentation .article-block-hide-excerpt .article-panel .excerpt,
+.user-css-presentation .article-block-hide-cover .article-panel .cover,
+.user-css-presentation .article-block-hide-details .article-panel .details {
+	display: none;
+}
 
-    --default1Muted: #1D1E0F;
-    --default2Muted: #2F3020;
-    --default3Muted: #414233;
-    --default4Muted: #505142;
-    --default5Muted: #626354;
-    --default6Muted: #747566;
-    --default7Muted: #838476;
-    --default8Muted: #959687;
-    --default9Muted: #A7A899;
-    --defaultAMuted: #B6B7A8;
-    --defaultBMuted: #C8C9BB;
-    --defaultCMuted: #DADBCB;
-    --defaultDMuted: #E9EADC;
-    --defaultEMuted: #FBFCED;
+.user-css-presentation .article-block-hide-details .article-panel .cover {
+	margin-bottom: -10px;
+}
 
-    --default1Transparent: rgba(29, 30, 15, 0.5);
-    --default2Transparent: rgba(47, 48, 32, 0.5);
-    --default3Transparent: rgba(65, 66, 51, 0.5);
-    --default4Transparent: rgba(80, 81, 66, 0.5);
-    --default5Transparent: rgba(98, 99, 84, 0.5);
-    --default6Transparent: rgba(116, 117, 102, 0.5);
-    --default7Transparent: rgba(131, 132, 118, 0.5);
-    --default8Transparent: rgba(149, 150, 135, 0.5);
-    --default9Transparent: rgba(167, 168, 153, 0.5);
-    --defaultATransparent: rgba(182, 183, 168, 0.5);
-    --defaultBTransparent: rgba(200, 201, 187, 0.5);
-    --defaultCTransparent: rgba(218, 219, 203, 0.5);
-    --defaultDTransparent: rgba(233, 234, 220, 0.5);
-    --defaultETransparent: rgba(251, 252, 237, 0.5);
+.user-css-presentation .paragraph-indent p {
+	text-indent: 25px;
+}
 
-    /* Primary Color: Red-Orange (Hue 10, Sat 100) */
-    --primary1: #1C0500;
-    --primary2: #2D0800;
-    --primary3: #3F0700;
-    --primary4: #4F0900;
-    --primary5: #601300;
-    --primary6: #720D00;
-    --primary7: #821100;
-    --primary8: #931100;
-    --primary9: #A51300;
-    --primaryA: #B52100;
-    --primaryB: #C61A00;
-    --primaryC: #D82700;
-    --primaryD: #E52200;
-    --primaryE: #F91D00;
+.user-css-presentation .paragraph-indent :not(p), .user-css-presentation .paragraph-indent p * {
+	text-indent: 0;
+}
 
-    --primary1Muted: #1E120F;
-    --primary2Muted: #302320;
-    --primary3Muted: #423533;
-    --primary4Muted: #514442;
-    --primary5Muted: #635754;
-    --primary6Muted: #756866;
-    --primary7Muted: #847876;
-    --primary8Muted: #968987;
-    --primary9Muted: #A89B99;
-    --primaryAMuted: #B7ABA8;
-    --primaryBMuted: #C9BDBB;
-    --primaryCMuted: #DBCECB;
-    --primaryDMuted: #E8DEDC;
-    --primaryEMuted: #FCEFED;
+.user-css-presentation .line-spacer {
+	display: none;
+}
 
-    --primary1Transparent: rgba(28, 5, 0, 0.5);
-    --primary2Transparent: rgba(45, 8, 0, 0.5);
-    --primary3Transparent: rgba(63, 7, 0, 0.5);
-    --primary4Transparent: rgba(79, 9, 0, 0.5);
-    --primary5Transparent: rgba(96, 19, 0, 0.5);
-    --primary6Transparent: rgba(114, 13, 0, 0.5);
-    --primary7Transparent: rgba(130, 17, 0, 0.5);
-    --primary8Transparent: rgba(147, 17, 0, 0.5);
-    --primary9Transparent: rgba(165, 19, 0, 0.5);
-    --primaryATransparent: rgba(181, 33, 0, 0.5);
-    --primaryBTransparent: rgba(198, 26, 0, 0.5);
-    --primaryCTransparent: rgba(219, 39, 0, 0.5);
-    --primaryDTransparent: rgba(229, 34, 0, 0.5);
-    --primaryETransparent: rgba(249, 29, 0, 0.5);
+.user-css-presentation .comment-box .line-spacer, .user-css-presentation .panel-greatgm .line-spacer {
+	display: block;
+}
 
-    /* Accent Color: Teal (Hue 186) */
-    --accent1: #0F1D1E;
-    --accent2: #202F30;
-    --accent3: #334142;
-    --accent4: #425051;
-    --accent5: #546263;
-    --accent6: #667475;
-    --accent7: #768384;
-    --accent8: #879596;
-    --accent9: #99A7A8;
-    --accentA: #A8B6B7;
-    --accentB: #BBC8C9;
-    --accentC: #CBDADB;
-    --accentD: #DCE9EA;
-    --accentE: #EDFBFC;
+.user-css-presentation .flexbox-valign-middle {
+	display: flex;
+	align-items: center;
+}
 
-    --accent1Muted: #0F1D1E;
-    --accent2Muted: #202F30;
-    --accent3Muted: #334142;
-    --accent4Muted: #425051;
-    --accent5Muted: #546263;
-    --accent6Muted: #667475;
-    --accent7Muted: #768384;
-    --accent8Muted: #879596;
-    --accent9Muted: #99A7A8;
-    --accentAMuted: #A8B6B7;
-    --accentBMuted: #BBC8C9;
-    --accentCMuted: #CBDADB;
-    --accentDMuted: #DCE9EA;
-    --accentEMuted: #EDFBFC;
+.user-css-presentation .user-css.page, .user-css-presentation .user-css-extended .page, .user-css-presentation .user-css-worldmenu .worldmenu-inner {
+	background-color: var(--default3MutedTransparent);
+}
 
-    --accent1Transparent: rgba(15, 29, 30, 0.5);
-    --accent2Transparent: rgba(32, 47, 48, 0.5);
-    --accent3Transparent: rgba(51, 65, 66, 0.5);
-    --accent4Transparent: rgba(66, 80, 81, 0.5);
-    --accent5Transparent: rgba(84, 98, 99, 0.5);
-    --accent6Transparent: rgba(102, 116, 117, 0.5);
-    --accent7Transparent: rgba(118, 131, 132, 0.5);
-    --accent8Transparent: rgba(135, 149, 150, 0.5);
-    --accent9Transparent: rgba(153, 167, 168, 0.5);
-    --accentATransparent: rgba(168, 182, 183, 0.5);
-    --accentBTransparent: rgba(187, 200, 201, 0.5);
-    --accentCTransparent: rgba(203, 218, 219, 0.5);
-    --accentDTransparent: rgba(220, 233, 234, 0.5);
-    --accentETransparent: rgba(237, 251, 252, 0.5);
+.user-css-presentation .hide-sidebar .tab-content .col-md-4 {
+	display: none;
+}
 
-    /* Specialty Colors */
-    --midPrimaryAccentA: #AF6C5C; /* Used for h3 */
-    --midPrimaryAccent8: #8D534B; /* Used for h3 small */
-    --midDefaultAccentA: #AFB7B0; /* Used for h5 */
-    --midDefaultAccent8: #9FA69F; /* Used for h5 small */
-    --defaultAFullTransparent: rgba(182, 183, 168, 0); /* Used for row border groups */
+.user-css-presentation .hide-sidebar .tab-content .col-md-8 {
+	width: 100%;
+}
+
+.user-css-presentation .hide-sidebar .tab-content .col-md-8 .col-md-8 {
+	width: 66.6667%;
+}
+
+.user-css-presentation .hide-sidebar .tab-content .col-md-8 .col-md-4 {
+	display: block;
+}
+
+.user-css-presentation .alert-default {
+	border-color: var(--defaultETransparent);
+	box-shadow: 0 0 2px 2px var(--defaultETransparent);
+}
+
+.user-css-presentation .alert-default h5:first-child {
+	color: var(--default3);
+}
+
+.user-css-presentation .alert-primary {
+	border-color: var(--primaryETransparent);
+	box-shadow: 0 0 2px 2px var(--primaryETransparent);
+}
+
+.user-css-presentation .alert-primary h5:first-child {
+	color: var(--primary3);
+}
+
+.user-css-presentation .alert-secondary {
+	border-color: var(--accentETransparent);
+	box-shadow: 0 0 2px 2px var(--accentETransparent);
+}
+
+.user-css-presentation .alert-secondary h5:first-child {
+	color: var(--accent3);
+}
+
+.user-css-presentation .alert-danger {
+	border-color: var(--dangerETransparent);
+	box-shadow: 0 0 2px 2px var(--dangerETransparent);
+}
+
+.user-css-presentation .alert-danger h5:first-child {
+	color: var(--danger3);
+}
+
+.user-css-presentation .alert-warning {
+	border-color: var(--warningETransparent);
+	box-shadow: 0 0 2px 2px var(--warningETransparent);
+}
+
+.user-css-presentation .alert-warning h5:first-child {
+	color: var(--warning3);
+}
+
+.user-css-presentation .alert-success {
+	border-color: var(--successETransparent);
+	box-shadow: 0 0 2px 2px var(--successETransparent);
+}
+
+.user-css-presentation .alert-success h5:first-child {
+	color: var(--success3);
+}
+
+.user-css-presentation .alert-info {
+	border-color: var(--infoETransparent);
+	box-shadow: 0 0 2px 2px var(--infoETransparent);
+}
+
+.user-css-presentation .alert-info h5:first-child {
+	color: var(--info3);
+}
+
+.user-css-presentation .relationScore {
+	display: none;
+}
+
+/* Color Theme: Default (Midnight Dusk) */
+.user-css-presentation .user-css, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
+	/* Default Color: Muted Blue (Hue 65) */
+	--default1: #111121;
+	--default2: #222232;
+	--default3: #333343;
+	--default4: #444454;
+	--default5: #555565;
+	--default6: #666676;
+	--default7: #777787;
+	--default8: #888898;
+	--default9: #9999A9;
+	--defaultA: #AAAABA;
+	--defaultB: #BBBBCB;
+	--defaultC: #CCCCDC;
+	--defaultD: #DDDDED;
+	--defaultE: #EEEEFE;
+
+	--default1Muted: #111121;
+	--default2Muted: #222232;
+	--default3Muted: #333343;
+	--default4Muted: #444454;
+	--default5Muted: #555565;
+	--default6Muted: #666676;
+	--default7Muted: #777787;
+	--default8Muted: #888898;
+	--default9Muted: #9999A9;
+	--defaultAMuted: #AAAABA;
+	--defaultBMuted: #BBBBCB;
+	--defaultCMuted: #CCCCDC;
+	--defaultDMuted: #DDDDED;
+	--defaultEMuted: #EEEEFE;
+
+	--default1Transparent: rgba(17, 17, 33, 0.5);
+	--default2Transparent: rgba(34, 34, 50, 0.5);
+	--default3Transparent: rgba(51, 51, 67, 0.5);
+	--default4Transparent: rgba(68, 68, 84, 0.5);
+	--default5Transparent: rgba(85, 85, 101, 0.5);
+	--default6Transparent: rgba(102, 102, 118, 0.5);
+	--default7Transparent: rgba(119, 119, 135, 0.5);
+	--default8Transparent: rgba(136, 136, 152, 0.5);
+	--default9Transparent: rgba(153, 153, 169, 0.5);
+	--defaultATransparent: rgba(170, 170, 186, 0.5);
+	--defaultBTransparent: rgba(187, 187, 203, 0.5);
+	--defaultCTransparent: rgba(204, 204, 220, 0.5);
+	--defaultDTransparent: rgba(221, 221, 237, 0.5);
+	--defaultETransparent: rgba(238, 238, 254, 0.5);
+
+	/* Primary Color: Red-Orange (Hue 10, Sat 100) */
+	--primary1: #112111;
+	--primary2: #193019;
+	--primary3: #224222;
+	--primary4: #2A512A;
+	--primary5: #336333;
+	--primary6: #3C753C;
+	--primary7: #448444;
+	--primary8: #4E964E;
+	--primary9: #57A857;
+	--primaryA: #5FB75F;
+	--primaryB: #68C968;
+	--primaryC: #72DB72;
+	--primaryD: #79EA79;
+	--primaryE: #83FC83;
+
+	--primary1Muted: #112111;
+	--primary2Muted: #223222;
+	--primary3Muted: #334333;
+	--primary4Muted: #445444;
+	--primary5Muted: #556555;
+	--primary6Muted: #667666;
+	--primary7Muted: #778777;
+	--primary8Muted: #889888;
+	--primary9Muted: #99a999;
+	--primaryAMuted: #aabaaa;
+	--primaryBMuted: #bbcbbb;
+	--primaryCMuted: #ccdccc;
+	--primaryDMuted: #ddeddd;
+	--primaryEMuted: #eefeee;
+
+	--primary1Transparent: rgba(17, 33, 17, 0.5);
+	--primary2Transparent: rgba(25, 48, 25, 0.5);
+	--primary3Transparent: rgba(34, 66, 34, 0.5);
+	--primary4Transparent: rgba(42, 81, 42, 0.5);
+	--primary5Transparent: rgba(51, 99, 51, 0.5);
+	--primary6Transparent: rgba(60, 117, 60, 0.5);
+	--primary7Transparent: rgba(68, 132, 68, 0.5);
+	--primary8Transparent: rgba(78, 150, 78, 0.5);
+	--primary9Transparent: rgba(87, 168, 87, 0.5);
+	--primaryATransparent: rgba(95, 183, 95, 0.5);
+	--primaryBTransparent: rgba(104, 201, 104, 0.5);
+	--primaryCTransparent: rgba(114, 219, 114, 0.5);
+	--primaryDTransparent: rgba(121, 234, 121, 0.5);
+	--primaryETransparent: rgba(131, 252, 131, 0.5);
+
+	/* Accent Color: Teal (Hue 186) */
+	--accent1: #112121;
+	--accent2: #223232;
+	--accent3: #334343;
+	--accent4: #445454;
+	--accent5: #556565;
+	--accent6: #667676;
+	--accent7: #778787;
+	--accent8: #889898;
+	--accent9: #99a9a9;
+	--accentA: #aababa;
+	--accentB: #bbcbcb;
+	--accentC: #ccdcdc;
+	--accentD: #ddeded;
+	--accentE: #eefefe;
+
+	--accent1Muted: #112121;
+	--accent2Muted: #223232;
+	--accent3Muted: #334343;
+	--accent4Muted: #445454;
+	--accent5Muted: #556565;
+	--accent6Muted: #667676;
+	--accent7Muted: #778787;
+	--accent8Muted: #889898;
+	--accent9Muted: #99a9a9;
+	--accentAMuted: #aababa;
+	--accentBMuted: #bbcbcb;
+	--accentCMuted: #ccdcdc;
+	--accentDMuted: #ddeded;
+	--accentEMuted: #eefefe;
+
+	--accent1Transparent: rgba(17, 33, 33, 0.5);
+	--accent2Transparent: rgba(34, 50, 50, 0.5);
+	--accent3Transparent: rgba(51, 67, 67, 0.5);
+	--accent4Transparent: rgba(68, 84, 84, 0.5);
+	--accent5Transparent: rgba(85, 101, 101, 0.5);
+	--accent6Transparent: rgba(102, 118, 118, 0.5);
+	--accent7Transparent: rgba(119, 135, 135, 0.5);
+	--accent8Transparent: rgba(136, 152, 152, 0.5);
+	--accent9Transparent: rgba(153, 169, 169, 0.5);
+	--accentATransparent: rgba(170, 186, 186, 0.5);
+	--accentBTransparent: rgba(187, 203, 201, 0.5);
+	--accentCTransparent: rgba(204, 220, 220, 0.5);
+	--accentDTransparent: rgba(221, 237, 237, 0.5);
+	--accentETransparent: rgba(238, 254, 254, 0.5);
+
+	/* Specialty Colors */
+	--midPrimaryAccentA: #85B98D; /* Used for h3 */
+	--midPrimaryAccent8: #6B9773; /* Used for h3 small */
+	--midDefaultAccentA: #AAB2BA; /* Used for h5 */
+	--midDefaultAccent8: #889098; /* Used for h5 small */
+	--defaultAFullTransparent: rgba(170, 170, 186, 0); /* Used for row border groups */
+	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+}
+
+/* Color Theme: Arshan */
+.user-css-presentation .arshan, .user-css-presentation .tag-theme-arshan, .user-css-presentation .category-3eabf245-4dc1-42bc-ac01-d1c4a7988d2e, .user-css-presentation .category-ddc22845-e8f3-401f-9c59-c9a390bf619e {
+	/* Default Color: Muted Blue (Hue 65) */
+	--default1: #111111;
+	--default2: #222222;
+	--default3: #333333;
+	--default4: #444444;
+	--default5: #555555;
+	--default6: #666666;
+	--default7: #777777;
+	--default8: #888888;
+	--default9: #999999;
+	--defaultA: #AAAAAA;
+	--defaultB: #BBBBBB;
+	--defaultC: #CCCCCC;
+	--defaultD: #DDDDDD;
+	--defaultE: #EEEEEE;
+
+	--default1Muted: #111111;
+	--default2Muted: #222222;
+	--default3Muted: #333333;
+	--default4Muted: #444444;
+	--default5Muted: #555555;
+	--default6Muted: #666666;
+	--default7Muted: #777777;
+	--default8Muted: #888888;
+	--default9Muted: #999999;
+	--defaultAMuted: #AAAAAA;
+	--defaultBMuted: #BBBBBB;
+	--defaultCMuted: #CCCCCC;
+	--defaultDMuted: #DDDDDD;
+	--defaultEMuted: #EEEEEE;
+
+	--default1Transparent: rgba(17, 17, 17, 0.5);
+	--default2Transparent: rgba(34, 34, 34, 0.5);
+	--default3Transparent: rgba(51, 51, 51, 0.5);
+	--default4Transparent: rgba(68, 68, 68, 0.5);
+	--default5Transparent: rgba(85, 85, 85, 0.5);
+	--default6Transparent: rgba(102, 102, 102, 0.5);
+	--default7Transparent: rgba(119, 119, 119, 0.5);
+	--default8Transparent: rgba(136, 136, 136, 0.5);
+	--default9Transparent: rgba(153, 153, 153, 0.5);
+	--defaultATransparent: rgba(170, 170, 170, 0.5);
+	--defaultBTransparent: rgba(187, 187, 187, 0.5);
+	--defaultCTransparent: rgba(204, 204, 204, 0.5);
+	--defaultDTransparent: rgba(221, 221, 221, 0.5);
+	--defaultETransparent: rgba(238, 238, 238, 0.5);
+
+	/* Primary Color: Red-Orange (Hue 10, Sat 100) */
+	--primary1: #1E0C00;
+	--primary2: #2D1300;
+	--primary3: #3F1800;
+	--primary4: #4F1E00;
+	--primary5: #602600;
+	--primary6: #722B00;
+	--primary7: #822D00;
+	--primary8: #933B00;
+	--primary9: #A54200;
+	--primaryA: #B54800;
+	--primaryB: #C64500;
+	--primaryC: #D85D00;
+	--primaryD: #E86000;
+	--primaryE: #F95F00;
+
+	--primary1Muted: #1E150F;
+	--primary2Muted: #302720;
+	--primary3Muted: #423933;
+	--primary4Muted: #514842;
+	--primary5Muted: #635A54;
+	--primary6Muted: #756C66;
+	--primary7Muted: #847B76;
+	--primary8Muted: #968D87;
+	--primary9Muted: #A89F99;
+	--primaryAMuted: #B7AEA8;
+	--primaryBMuted: #C9C0BB;
+	--primaryCMuted: #DBD2CB;
+	--primaryDMuted: #EAE2DC;
+	--primaryEMuted: #FCF3ED;
+
+	--primary1Transparent: rgba(30, 12, 0, 0.5);
+	--primary2Transparent: rgba(45, 19, 0, 0.5);
+	--primary3Transparent: rgba(63, 24, 0, 0.5);
+	--primary4Transparent: rgba(79, 30, 0, 0.5);
+	--primary5Transparent: rgba(96, 38, 0, 0.5);
+	--primary6Transparent: rgba(114, 43, 0, 0.5);
+	--primary7Transparent: rgba(130, 45, 0, 0.5);
+	--primary8Transparent: rgba(147, 59, 0, 0.5);
+	--primary9Transparent: rgba(165, 66, 0, 0.5);
+	--primaryATransparent: rgba(181, 72, 0, 0.5);
+	--primaryBTransparent: rgba(198, 69, 0, 0.5);
+	--primaryCTransparent: rgba(216, 93, 0, 0.5);
+	--primaryDTransparent: rgba(232, 96, 0, 0.5);
+	--primaryETransparent: rgba(249, 95, 0, 0.5);
+
+	/* Accent Color: Teal (Hue 186) */
+	--accent1: #1E150F;
+	--accent2: #302720;
+	--accent3: #423933;
+	--accent4: #514842;
+	--accent5: #635A54;
+	--accent6: #756C66;
+	--accent7: #847B76;
+	--accent8: #968D87;
+	--accent9: #A89F99;
+	--accentA: #B7AEA8;
+	--accentB: #C9C0BB;
+	--accentC: #DBD2CB;
+	--accentD: #EAE2DC;
+	--accentE: #FCF3ED;
+
+	--accent1Muted: #1E150F;
+	--accent2Muted: #302720;
+	--accent3Muted: #423933;
+	--accent4Muted: #514842;
+	--accent5Muted: #635A54;
+	--accent6Muted: #756C66;
+	--accent7Muted: #847B76;
+	--accent8Muted: #968D87;
+	--accent9Muted: #A89F99;
+	--accentAMuted: #B7AEA8;
+	--accentBMuted: #C9C0BB;
+	--accentCMuted: #DBD2CB;
+	--accentDMuted: #EAE2DC;
+	--accentEMuted: #FCF3ED;
+
+	--accent1Transparent: rgba(30, 21, 15, 0.5);
+	--accent2Transparent: rgba(40, 39, 32, 0.5);
+	--accent3Transparent: rgba(66, 57, 51, 0.5);
+	--accent4Transparent: rgba(81, 72, 66, 0.5);
+	--accent5Transparent: rgba(99, 90, 84, 0.5);
+	--accent6Transparent: rgba(117, 108, 102, 0.5);
+	--accent7Transparent: rgba(132, 123, 118, 0.5);
+	--accent8Transparent: rgba(150, 141, 135, 0.5);
+	--accent9Transparent: rgba(168, 159, 153, 0.5);
+	--accentATransparent: rgba(183, 174, 168, 0.5);
+	--accentBTransparent: rgba(201, 192, 187, 0.5);
+	--accentCTransparent: rgba(219, 210, 203, 0.5);
+	--accentDTransparent: rgba(234, 226, 220, 0.5);
+	--accentETransparent: rgba(252, 243, 237, 0.5);
+
+	/* Specialty Colors */
+	--midPrimaryAccentA: #C98456; /* Used for h3 */
+	--midPrimaryAccent8: #966544; /* Used for h3 small */
+	--midDefaultAccentA: #C9C0BA; /* Used for h5 */
+	--midDefaultAccent8: #96928F; /* Used for h5 small */
+	--defaultAFullTransparent: rgba(170, 170, 186, 0); /* Used for row border groups */
+	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+}
+
+/* Color Theme: Drakari */
+.user-css-presentation .drakari, .user-css-presentation .tag-theme-drakari, .user-css-presentation .category-ea4be012-9100-4767-85ab-be1e9f3ad706, .user-css-presentation .category-3bf6bdc2-817f-4056-be26-e358879cdc5d {
+	/* Default Color: Muted rED (Hue 0) */
+	--default1: #211111;
+	--default2: #322222;
+	--default3: #433333;
+	--default4: #544444;
+	--default5: #655555;
+	--default6: #766666;
+	--default7: #877777;
+	--default8: #988888;
+	--default9: #A99999;
+	--defaultA: #BAAAAA;
+	--defaultB: #CBBBBB;
+	--defaultC: #DCCCCC;
+	--defaultD: #EDDDDD;
+	--defaultE: #FEEEEE;
+
+	--default1Muted: #211111;
+	--default2Muted: #322222;
+	--default3Muted: #433333;
+	--default4Muted: #544444;
+	--default5Muted: #655555;
+	--default6Muted: #766666;
+	--default7Muted: #877777;
+	--default8Muted: #988888;
+	--default9Muted: #A99999;
+	--defaultAMuted: #BAAAAA;
+	--defaultBMuted: #CBBBBB;
+	--defaultCMuted: #DCCCCC;
+	--defaultDMuted: #EDDDDD;
+	--defaultEMuted: #FEEEEE;
+
+	--default1Transparent: rgba(33, 17, 17, 0.5);
+	--default2Transparent: rgba(50, 34, 34, 0.5);
+	--default3Transparent: rgba(67, 51, 51, 0.5);
+	--default4Transparent: rgba(84, 68, 68, 0.5);
+	--default5Transparent: rgba(101, 85, 85, 0.5);
+	--default6Transparent: rgba(118, 102, 102, 0.5);
+	--default7Transparent: rgba(135, 119, 119, 0.5);
+	--default8Transparent: rgba(152, 136, 136, 0.5);
+	--default9Transparent: rgba(169, 153, 153, 0.5);
+	--defaultATransparent: rgba(186, 170, 170, 0.5);
+	--defaultBTransparent: rgba(203, 187, 187, 0.5);
+	--defaultCTransparent: rgba(220, 204, 204, 0.5);
+	--defaultDTransparent: rgba(237, 221, 221, 0.5);
+	--defaultETransparent: rgba(254, 238, 238, 0.5);
+
+	/* Primary Color: Purple->Yellow */
+	--primary1: #1A031C;
+	--primary2: #2B052D;
+	--primary3: #3F0A36;
+	--primary4: #4F0F3B;
+	--primary5: #60173D;
+	--primary6: #721E3F;
+	--primary7: #82293C;
+	--primary8: #93353D;
+	--primary9: #A54F45;
+	--primaryA: #B5674D;
+	--primaryB: #C68A5F;
+	--primaryC: #D8AD70;
+	--primaryD: #E8CE81;
+	--primaryE: #F9EF95;
+
+	--primary1Muted: #1C0E1C;
+	--primary2Muted: #2D212B;
+	--primary3Muted: #3F313C;
+	--primary4Muted: #4F4149;
+	--primary5Muted: #605358;
+	--primary6Muted: #726468;
+	--primary7Muted: #827376;
+	--primary8Muted: #938586;
+	--primary9Muted: #A59998;
+	--primaryAMuted: #B5ABA8;
+	--primaryBMuted: #C6BFBA;
+	--primaryCMuted: #D8D3CD;
+	--primaryDMuted: #E8E5DC;
+	--primaryEMuted: #F9F8EF;
+
+	--primary1Transparent: rgba(36, 3, 28, 0.5);
+	--primary2Transparent: rgba(43, 5, 45, 0.5);
+	--primary3Transparent: rgba(63, 10, 54, 0.5);
+	--primary4Transparent: rgba(79, 15, 59, 0.5);
+	--primary5Transparent: rgba(96, 23, 61, 0.5);
+	--primary6Transparent: rgba(114, 30, 61, 0.5);
+	--primary7Transparent: rgba(130, 41, 60, 0.5);
+	--primary8Transparent: rgba(147, 53, 61, 0.5);
+	--primary9Transparent: rgba(165, 79, 69, 0.5);
+	--primaryATransparent: rgba(181, 103, 77, 0.5);
+	--primaryBTransparent: rgba(198, 138, 95, 0.5);
+	--primaryCTransparent: rgba(216, 173, 112, 0.5);
+	--primaryDTransparent: rgba(232, 206, 129, 0.5);
+	--primaryETransparent: rgba(249, 239, 149, 0.5);
+
+	/* Accent Color: Purple->Yellow */
+	--accent1: #1C0110;
+	--accent2: #2D011A;
+	--accent3: #3F0A1C;
+	--accent4: #4F0E21;
+	--accent5: #601824;
+	--accent6: #722527;
+	--accent7: #823B34;
+	--accent8: #935945;
+	--accent9: #A5765B;
+	--accentA: #B59572;
+	--accentB: #C6B08B;
+	--accentC: #D8CDA9;
+	--accentD: #E8E2C7;
+	--accentE: #F9F9E8;
+
+	--accent1Muted: #1C0D17;
+	--accent2Muted: #2D2127;
+	--accent3Muted: #3F3538;
+	--accent4Muted: #4F4446;
+	--accent5Muted: #605859;
+	--accent6Muted: #726868;
+	--accent7Muted: #827977;
+	--accent8Muted: #938A88;
+	--accent9Muted: #A59D9A;
+	--accentAMuted: #B5AEA8;
+	--accentBMuted: #C6C1BA;
+	--accentCMuted: #D8D6CD;
+	--accentDMuted: #E8E6DC;
+	--accentEMuted: #F9F9ED;
+
+	--accent1Transparent: rgba(28, 1, 16, 0.5);
+	--accent2Transparent: rgba(45, 1, 26, 0.5);
+	--accent3Transparent: rgba(63, 10, 28, 0.5);
+	--accent4Transparent: rgba(79, 14, 33, 0.5);
+	--accent5Transparent: rgba(96, 24, 36, 0.5);
+	--accent6Transparent: rgba(114, 37, 39, 0.5);
+	--accent7Transparent: rgba(130, 59, 52, 0.5);
+	--accent8Transparent: rgba(147, 89, 69, 0.5);
+	--accent9Transparent: rgba(165, 118, 91, 0.5);
+	--accentATransparent: rgba(181, 149, 114, 0.5);
+	--accentBTransparent: rgba(198, 176, 139, 0.5);
+	--accentCTransparent: rgba(216, 205, 169, 0.5);
+	--accentDTransparent: rgba(232, 223, 199, 0.5);
+	--accentETransparent: rgba(249, 249, 232, 0.5);
+
+	/* Specialty Colors */
+	--midPrimaryAccentA: #B57E60; /* Used for h3 */
+	--midPrimaryAccent8: #934741; /* Used for h3 small */
+	--midDefaultAccentA: #B8A08E; /* Used for h5 */
+	--midDefaultAccent8: #967167; /* Used for h5 small */
+	--defaultAFullTransparent: rgba(186, 170, 170, 0); /* Used for row border groups */
+	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+}
+
+/* Color Theme: Solus */
+.user-css-presentation .solus, .user-css-presentation .tag-theme-solus, .user-css-presentation .category-1eb3624c-9c1c-4c81-aaa2-144280de91b0, .user-css-presentation .category-66c5e6cd-d242-4156-aed4-18f0a3183e2f {
+	/* Default Color: Muted Blue-Green */
+	--default1: #0F191E;
+	--default2: #202B30;
+	--default3: #333D42;
+	--default4: #424C51;
+	--default5: #545E63;
+	--default6: #667075;
+	--default7: #767F84;
+	--default8: #879196;
+	--default9: #99A3A8;
+	--defaultA: #A8B2B7;
+	--defaultB: #BBC4C9;
+	--defaultC: #CBD6DB;
+	--defaultD: #DCE5EA;
+	--defaultE: #EDF7FC;
+
+	--default1Muted: #0F191E;
+	--default2Muted: #202B30;
+	--default3Muted: #333D42;
+	--default4Muted: #424C51;
+	--default5Muted: #545E63;
+	--default6Muted: #667075;
+	--default7Muted: #767F84;
+	--default8Muted: #879196;
+	--default9Muted: #99A3A8;
+	--defaultAMuted: #A8B2B7;
+	--defaultBMuted: #BBC4C9;
+	--defaultCMuted: #CBD6DB;
+	--defaultDMuted: #DCE5EA;
+	--defaultEMuted: #EDF7FC;
+
+	--default1Transparent: rgba(15, 25, 30, 0.5);
+	--default2Transparent: rgba(32, 43, 48, 0.5);
+	--default3Transparent: rgba(51, 61, 66, 0.5);
+	--default4Transparent: rgba(66, 76, 81, 0.5);
+	--default5Transparent: rgba(84, 94, 99, 0.5);
+	--default6Transparent: rgba(102, 112, 117, 0.5);
+	--default7Transparent: rgba(118, 127, 132, 0.5);
+	--default8Transparent: rgba(135, 145, 150, 0.5);
+	--default9Transparent: rgba(153, 163, 168, 0.5);
+	--defaultATransparent: rgba(168, 178, 183, 0.5);
+	--defaultBTransparent: rgba(187, 196, 201, 0.5);
+	--defaultCTransparent: rgba(203, 214, 219, 0.5);
+	--defaultDTransparent: rgba(220, 229, 234, 0.5);
+	--defaultETransparent: rgba(237, 247, 252, 0.5);
+
+	/* Primary Color: Yellow */
+	--primary1: #1E0800;
+	--primary2: #300C00;
+	--primary3: #421600;
+	--primary4: #512101;
+	--primary5: #632D01;
+	--primary6: #753E03;
+	--primary7: #844F05;
+	--primary8: #966306;
+	--primary9: #A87A08;
+	--primaryA: #B7920B;
+	--primaryB: #C9AD0C;
+	--primaryC: #DBCA0F;
+	--primaryD: #EAEA10;
+	--primaryE: #FCFC11;
+
+	--primary1Muted: #1C120E;
+	--primary2Muted: #2D221F;
+	--primary3Muted: #3F3531;
+	--primary4Muted: #4F4640;
+	--primary5Muted: #605852;
+	--primary6Muted: #726B63;
+	--primary7Muted: #827B73;
+	--primary8Muted: #938E85;
+	--primary9Muted: #A5A196;
+	--primaryAMuted: #B5B1A6;
+	--primaryBMuted: #C6C4B8;
+	--primaryCMuted: #D8D7C9;
+	--primaryDMuted: #E8E8DA;
+	--primaryEMuted: #F9F9EA;
+
+	--primary1Transparent: rgba(30, 8, 0, 0.5);
+	--primary2Transparent: rgba(48, 12, 0, 0.5);
+	--primary3Transparent: rgba(66, 22, 0, 0.5);
+	--primary4Transparent: rgba(81, 33, 1, 0.5);
+	--primary5Transparent: rgba(99, 45, 1, 0.5);
+	--primary6Transparent: rgba(117, 62, 3, 0.5);
+	--primary7Transparent: rgba(132, 79, 5, 0.5);
+	--primary8Transparent: rgba(150, 99, 6, 0.5);
+	--primary9Transparent: rgba(168, 122, 8, 0.5);
+	--primaryATransparent: rgba(183, 146, 11, 0.5);
+	--primaryBTransparent: rgba(207, 173, 12, 0.5);
+	--primaryCTransparent: rgba(219, 202, 15, 0.5);
+	--primaryDTransparent: rgba(234, 234, 16, 0.5);
+	--primaryETransparent: rgba(252, 252, 17, 0.5);
+
+	/* Accent Color: Muted Green */
+	--accent1: #141E0F;
+	--accent2: #263020;
+	--accent3: #384233;
+	--accent4: #475142;
+	--accent5: #596354;
+	--accent6: #6B7566;
+	--accent7: #7A8476;
+	--accent8: #8C9687;
+	--accent9: #9EA899;
+	--accentA: #ADB7A8;
+	--accentB: #C0C9BB;
+	--accentC: #D1DBCB;
+	--accentD: #E1EADC;
+	--accentE: #F2FCED;
+
+	--accent1Muted: #141E0F;
+	--accent2Muted: #263020;
+	--accent3Muted: #384233;
+	--accent4Muted: #475142;
+	--accent5Muted: #596354;
+	--accent6Muted: #6B7566;
+	--accent7Muted: #7A8476;
+	--accent8Muted: #8C9687;
+	--accent9Muted: #9EA899;
+	--accentAMuted: #ADB7A8;
+	--accentBMuted: #C0C9BB;
+	--accentCMuted: #D1DBCB;
+	--accentDMuted: #E1EADC;
+	--accentEMuted: #F2FCED;
+
+	--accent1Transparent: rgba(20, 30, 15, 0.5);
+	--accent2Transparent: rgba(38, 48, 32, 0.5);
+	--accent3Transparent: rgba(56, 66, 51, 0.5);
+	--accent4Transparent: rgba(71, 81, 66, 0.5);
+	--accent5Transparent: rgba(89, 99, 84, 0.5);
+	--accent6Transparent: rgba(107, 117, 102, 0.5);
+	--accent7Transparent: rgba(122, 132, 118, 0.5);
+	--accent8Transparent: rgba(140, 150, 135, 0.5);
+	--accent9Transparent: rgba(158, 168, 153, 0.5);
+	--accentATransparent: rgba(173, 183, 168, 0.5);
+	--accentBTransparent: rgba(192, 201, 187, 0.5);
+	--accentCTransparent: rgba(209, 219, 203, 0.5);
+	--accentDTransparent: rgba(225, 235, 220, 0.5);
+	--accentETransparent: rgba(242, 252, 237, 0.5);
+
+	/* Specialty Colors */
+	--midPrimaryAccentA: #B2A55A; /* Used for h3 */
+	--midPrimaryAccent8: #917D47; /* Used for h3 small */
+	--midDefaultAccentA: #ABB5B0; /* Used for h5 */
+	--midDefaultAccent8: #8A948F; /* Used for h5 small */
+	--defaultAFullTransparent: rgba(186, 170, 170, 0); /* Used for row border groups */
+	--default3MutedTransparent: var(--default3Transparent); /* Used for body background */
+}
+
+/* Color Theme: Terran */
+.user-css-presentation .terran, .user-css-presentation .tag-theme-terran, .user-css-presentation .category-f680cb8b-4874-4152-806a-35d2b42c6c0b, .user-css-presentation .category-5162d4c3-0773-4b70-b1aa-dc2d9d495d27 {
+	/* Default Color: Green-Yellow */
+	--default1: #151C07;
+	--default2: #232E0D;
+	--default3: #303F13;
+	--default4: #3E5017;
+	--default5: #4C601A;
+	--default6: #5C711D;
+	--default7: #6C8220;
+	--default8: #839523;
+	--default9: #99A826;
+	--defaultA: #ACB727;
+	--defaultB: #BEC627;
+	--defaultC: #CED72B;
+	--defaultD: #DEE82E;
+	--defaultE: #EBF430;
+
+	--default1Muted: #15190C;
+	--default2Muted: #292D1E;
+	--default3Muted: #383D2F;
+	--default4Muted: #4A4F40;
+	--default5Muted: #5A5E50;
+	--default6Muted: #6C7062;
+	--default7Muted: #7C7F72;
+	--default8Muted: #919385;
+	--default9Muted: #A4A598;
+	--defaultAMuted: #B4B5A6;
+	--defaultBMuted: #C3C4B8;
+	--defaultCMuted: #D5D6C7;
+	--defaultDMuted: #E4E5DA;
+	--defaultEMuted: #F1F2E6;
+
+	--default1Transparent: rgba(21, 28, 7, 0.5);
+	--default2Transparent: rgba(35, 46, 13, 0.5);
+	--default3Transparent: rgba(48, 63, 19, 0.5);
+	--default4Transparent: rgba(62, 80, 23, 0.5);
+	--default5Transparent: rgba(76, 96, 26, 0.5);
+	--default6Transparent: rgba(92, 113, 29, 0.5);
+	--default7Transparent: rgba(108, 130, 32, 0.5);
+	--default8Transparent: rgba(131, 149, 35, 0.5);
+	--default9Transparent: rgba(153, 168, 38, 0.5);
+	--defaultATransparent: rgba(172, 183, 39, 0.5);
+	--defaultBTransparent: rgba(190, 198, 39, 0.5);
+	--defaultCTransparent: rgba(206, 215, 43, 0.5);
+	--defaultDTransparent: rgba(222, 232, 46, 0.5);
+	--defaultETransparent: rgba(235, 244, 48, 0.5);
+
+	/* Primary Color: Cyan */
+	--primary1: #020819;
+	--primary2: #05132B;
+	--primary3: #081D3D;
+	--primary4: #0E2C4E;
+	--primary5: #133B5E;
+	--primary6: #1B4E6F;
+	--primary7: #22607F;
+	--primary8: #2C7992;
+	--primary9: #3691A5;
+	--primaryA: #41A8B5;
+	--primaryB: #4CBEC4;
+	--primaryC: #5AD2CF;
+	--primaryD: #67E5DA;
+	--primaryE: #6DF2E9;
+
+	--primary1Muted: #0B0E16;
+	--primary2Muted: #1B2028;
+	--primary3Muted: #2D323A;
+	--primary4Muted: #3E454C;
+	--primary5Muted: #4E555B;
+	--primary6Muted: #60686D;
+	--primary7Muted: #70787C;
+	--primary8Muted: #848E91;
+	--primary9Muted: #97A1A3;
+	--primaryAMuted: #A4B1B2;
+	--primaryBMuted: #B6C1C1;
+	--primaryCMuted: #C2D1D0;
+	--primaryDMuted: #D9E2E2;
+	--primaryEMuted: #E6EFEE;
+
+	--primary1Transparent: rgba(2, 8, 25, 0.5);
+	--primary2Transparent: rgba(5, 19, 49, 0.5);
+	--primary3Transparent: rgba(8, 29, 61, 0.5);
+	--primary4Transparent: rgba(14, 44, 78, 0.5);
+	--primary5Transparent: rgba(19, 59, 94, 0.5);
+	--primary6Transparent: rgba(27, 78, 111, 0.5);
+	--primary7Transparent: rgba(34, 96, 127, 0.5);
+	--primary8Transparent: rgba(44, 121, 146, 0.5);
+	--primary9Transparent: rgba(54, 145, 165, 0.5);
+	--primaryATransparent: rgba(65, 168, 181, 0.5);
+	--primaryBTransparent: rgba(76, 190, 196, 0.5);
+	--primaryCTransparent: rgba(91, 210, 207, 0.5);
+	--primaryDTransparent: rgba(103, 229, 218, 0.5);
+	--primaryETransparent: rgba(109, 242, 233, 0.5);
+
+	/* Accent Color: Moss Green */
+	--accent1: #041910;
+	--accent2: #0A2B17;
+	--accent3: #103D1E;
+	--accent4: #194C21;
+	--accent5: #225B23;
+	--accent6: #336C2E;
+	--accent7: #447C39;
+	--accent8: #5F904A;
+	--accent9: #79A35B;
+	--accentA: #92B26D;
+	--accentB: #AAC17F;
+	--accentC: #C2D383;
+	--accentD: #DAE587;
+	--accentE: #ECF4BA;
+
+	--accent1Muted: #0B1611;
+	--accent2Muted: #1B2820;
+	--accent3Muted: #2D3A31;
+	--accent4Muted: #3C493E;
+	--accent5Muted: #4C594C;
+	--accent6Muted: #606B5F;
+	--accent7Muted: #717A6F;
+	--accent8Muted: #858E81;
+	--accent9Muted: #9AA095;
+	--accentAMuted: #AAAFA3;
+	--accentBMuted: #BCBFB5;
+	--accentCMuted: #D2D6C7;
+	--accentDMuted: #ECEDE6;
+	--accentEMuted: #F1F2EA;
+
+	--accent1Transparent: rgba(4, 25, 16, 0.5);
+	--accent2Transparent: rgba(10, 43, 23, 0.5);
+	--accent3Transparent: rgba(16, 61, 30, 0.5);
+	--accent4Transparent: rgba(25, 76, 33, 0.5);
+	--accent5Transparent: rgba(34, 91, 35, 0.5);
+	--accent6Transparent: rgba(51, 108, 46, 0.5);
+	--accent7Transparent: rgba(64, 124, 57, 0.5);
+	--accent8Transparent: rgba(95, 144, 74, 0.5);
+	--accent9Transparent: rgba(121, 163, 91, 0.5);
+	--accentATransparent: rgba(146, 178, 109, 0.5);
+	--accentBTransparent: rgba(170, 193, 127, 0.5);
+	--accentCTransparent: rgba(194, 211, 131, 0.5);
+	--accentDTransparent: rgba(218, 229, 135, 0.5);
+	--accentETransparent: rgba(236, 244, 186, 0.5);
+
+	/* Specialty Colors */
+	--midPrimaryAccentA: #6AAD91; /* Used for h3 */
+	--midPrimaryAccent8: #46856E; /* Used for h3 small */
+	--midDefaultAccentA: #9FB54A; /* Used for h5 */
+	--midDefaultAccent8: #719337; /* Used for h5 small */
+	--defaultAFullTransparent: rgba(172, 183, 39, 0); /* Used for row border groups */
+	--default3MutedTransparent: rgba(56, 61, 47, 0.5); /* Used for body background */
+}
+
+.user-css-presentation .sionian, .user-css-presentation .tag-theme-sionian, .user-css-presentation .category-723c6440-ca73-4e61-b35c-9d66dd1a27d0, .user-css-presentation .category-264de840-9175-4c60-935f-ff5ce2eeb023 {
+	/* Default Color: Muted Tan */
+	--default1: #1E0F01;
+	--default2: #302011;
+	--default3: #423323;
+	--default4: #514232;
+	--default5: #635445;
+	--default6: #756656;
+	--default7: #847667;
+	--default8: #968778;
+	--default9: #A8998A;
+	--defaultA: #B7A89A;
+	--defaultB: #C9BBAD;
+	--defaultC: #DBCBBC;
+	--defaultD: #EADCCE;
+	--defaultE: #FCEDDE;
+
+	--default1Muted: #1E0F01;
+	--default2Muted: #302011;
+	--default3Muted: #423323;
+	--default4Muted: #514232;
+	--default5Muted: #635445;
+	--default6Muted: #756656;
+	--default7Muted: #847667;
+	--default8Muted: #968778;
+	--default9Muted: #A8998A;
+	--defaultAMuted: #B7A89A;
+	--defaultBMuted: #C9BBAD;
+	--defaultCMuted: #DBCBBC;
+	--defaultDMuted: #EADCCE;
+	--defaultEMuted: #FCEDDE;
+
+	--default1Transparent: rgba(30, 15, 1, 0.5);
+	--default2Transparent: rgba(48, 32, 17, 0.5);
+	--default3Transparent: rgba(66, 51, 35, 0.5);
+	--default4Transparent: rgba(81, 66, 50, 0.5);
+	--default5Transparent: rgba(99, 84, 69, 0.5);
+	--default6Transparent: rgba(117, 112, 86, 0.5);
+	--default7Transparent: rgba(132, 118, 103, 0.5);
+	--default8Transparent: rgba(150, 133, 120, 0.5);
+	--default9Transparent: rgba(168, 153, 138, 0.5);
+	--defaultATransparent: rgba(183, 168, 154, 0.5);
+	--defaultBTransparent: rgba(201, 187, 173, 0.5);
+	--defaultCTransparent: rgba(219, 203, 188, 0.5);
+	--defaultDTransparent: rgba(234, 220, 206, 0.5);
+	--defaultETransparent: rgba(252, 237, 222, 0.5);
+
+	/* Primary Color: Green */
+	--primary1: #071902;
+	--primary2: #0D2B07;
+	--primary3: #123D0B;
+	--primary4: #1A4E14;
+	--primary5: #215E1C;
+	--primary6: #2B6F28;
+	--primary7: #347F34;
+	--primary8: #449147;
+	--primary9: #53A359;
+	--primaryA: #67B46F;
+	--primaryB: #7BC484;
+	--primaryC: #91D59C;
+	--primaryD: #A7E5B3;
+	--primaryE: #B4F7C1;
+
+	--primary1Muted: #0E160B;
+	--primary2Muted: #1F281E;
+	--primary3Muted: #2F3A2D;
+	--primary4Muted: #434C42;
+	--primary5Muted: #505B4F;
+	--primary6Muted: #616D60;
+	--primary7Muted: #6F7C6F;
+	--primary8Muted: #818E82;
+	--primary9Muted: #95A096;
+	--primaryAMuted: #A6B2A7;
+	--primaryBMuted: #B6C1B7;
+	--primaryCMuted: #C9D3CA;
+	--primaryDMuted: #D7E2D9;
+	--primaryEMuted: #EBF4EC;
+
+	--primary1Transparent: rgba(7, 25, 2, 0.5);
+	--primary2Transparent: rgba(13, 43, 7, 0.5);
+	--primary3Transparent: rgba(18, 61, 11, 0.5);
+	--primary4Transparent: rgba(26, 78, 20, 0.5);
+	--primary5Transparent: rgba(33, 94, 28, 0.5);
+	--primary6Transparent: rgba(43, 111, 40, 0.5);
+	--primary7Transparent: rgba(52, 127, 52, 0.5);
+	--primary8Transparent: rgba(68, 145, 71, 0.5);
+	--primary9Transparent: rgba(83, 163, 89, 0.5);
+	--primaryATransparent: rgba(103, 180, 111, 0.5);
+	--primaryBTransparent: rgba(123, 196, 132, 0.5);
+	--primaryCTransparent: rgba(145, 213, 156, 0.5);
+	--primaryDTransparent: rgba(167, 229, 179, 0.5);
+	--primaryETransparent: rgba(180, 247, 193, 0.5);
+
+	/* Accent Color: Orange */
+	--accent1: #160A00;
+	--accent2: #281502;
+	--accent3: #3A1F04;
+	--accent4: #4B2C09;
+	--accent5: #5B390D;
+	--accent6: #6C4913;
+	--accent7: #7C5818;
+	--accent8: #8E6920;
+	--accent9: #A07A28;
+	--accentA: #B18D31;
+	--accentB: #C19F3A;
+	--accentC: #D2B546;
+	--accentD: #E2CA51;
+	--accentE: #F4DA58;
+
+	--accent1Muted: #140E0A;
+	--accent2Muted: #26211C;
+	--accent3Muted: #38312B;
+	--accent4Muted: #494540;
+	--accent5Muted: #59544D;
+	--accent6Muted: #6B665F;
+	--accent7Muted: #7A756E;
+	--accent8Muted: #8C877F;
+	--accent9Muted: #9E9B94;
+	--accentAMuted: #AFACA5;
+	--accentBMuted: #BFBCB5;
+	--accentCMuted: #D1CFC8;
+	--accentDMuted: #E0DED7;
+	--accentEMuted: #F2F0EA;
+
+	--accent1Transparent: rgba(22, 10, 0, 0.5);
+	--accent2Transparent: rgba(40, 21, 2, 0.5);
+	--accent3Transparent: rgba(58, 31, 4, 0.5);
+	--accent4Transparent: rgba(75, 44, 9, 0.5);
+	--accent5Transparent: rgba(91, 57, 13, 0.5);
+	--accent6Transparent: rgba(108, 73, 19, 0.5);
+	--accent7Transparent: rgba(124, 88, 24, 0.5);
+	--accent8Transparent: rgba(142, 105, 32, 0.5);
+	--accent9Transparent: rgba(160, 122, 40, 0.5);
+	--accentATransparent: rgba(177, 141, 49, 0.5);
+	--accentBTransparent: rgba(193, 159, 58, 0.5);
+	--accentCTransparent: rgba(210, 181, 70, 0.5);
+	--accentDTransparent: rgba(226, 202, 81, 0.5);
+	--accentETransparent: rgba(244, 218, 88, 0.5);
+
+	/* Specialty Colors */
+	--midPrimaryAccentA: #8CA150; /* Used for h3 */
+	--midPrimaryAccent8: #697D34; /* Used for h3 small */
+	--midDefaultAccentA: #B49B66; /* Used for h5 */
+	--midDefaultAccent8: #92784C; /* Used for h5 small */
+	--defaultAFullTransparent: rgba(172, 183, 39, 0); /* Used for row border groups */
+	--default3MutedTransparent: rgba(66, 51, 35, 0.5); /* Used for body background */
 }

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -2598,11 +2598,11 @@
     color: var(--accentDMuted);
 }
 
-.user-css-presentation .user-css-presentation-image-thumbnail {
+.user-css-presentation .user-css-image-thumbnail {
     background: var(--accent5Transparent);
 }
 
-.user-css-presentation .user-css-presentation-image-thumbnail .artist-credits {
+.user-css-presentation .user-css-image-thumbnail .artist-credits {
     background: var(--primary5Transparent);
     color: var(--primaryDMuted);
 }

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -2227,11 +2227,11 @@
 }
 
 .user-css-presentation .btn-link {
-    color: var(--primaryD);
+    color: var(--primaryD) !important;
 }
 
 .user-css-presentation .btn-link:hover {
-    color: var(--primaryDMuted);
+    color: var(--primaryDMuted) !important;
 }
 
 /* CARDS */


### PR DESCRIPTION
## [1.3.0] - 2018-07-14
### Added
 - New Inline version of GalaxyAnvil, intended for copy+pasta use in your world's CSS box if preferred over the WorldAnvil theme selection. See Releases for CSS file and more details.
 - Support for `.card-box` classes
 - borderRadius variables for easier customization
 - Support for WorldAnvil's new world presentation front page

### Fixed
 - Buttons in world header cover not rendering correctly

### Changed
 - Various tweaks and changes to incorporate the 2018 theme update's changes.
 - World menu and map boxes now use accent colors instead of primary.
 - Tweaked font sizes of various elements to improve readability.
 - Restyled timeline panels