### PR TITLE
GalaxyAnvil v1.4.0 - Hard Reset

### DIFF
--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1,6 +1,6 @@
 /*
  * GalaxyAnvil - A theme for WorldAnvil, created by SierraKomodo
- * Version 1.3.0
+ * Version 1.4.0
  * https://github.com/SierraKomodo/worldanvil-templates/tree/GalaxyAnvil
  */
 
@@ -509,7 +509,7 @@
     min-height: 70px;
 }
 
-.user-css-presentation .alert h5:first-child {
+.user-css-presentation .alert h5:first-of-type {
     padding: 5px 10px;
     margin: 0 0 10px 0;
     position: absolute;
@@ -526,6 +526,10 @@
     font-family: inherit;
     font-size: 1.4rem;
     margin: 2px 1px;
+}
+
+.user-css-presentation button.close {
+    opacity: inherit;
 }
 
 .user-css-presentation .breadcrumb {
@@ -555,6 +559,19 @@
     margin: .5em .1em;
 }
 
+.user-css-presentation .modal-dialog .modal-footer,
+.user-css-presentation .modal-dialog .modal-bottom,
+.user-css-presentation .modal-dialog .modal-header {
+    border: none;
+}
+
+.user-css-presentation .nav-pills li {
+    border:none;
+    border-radius: var(--borderRadius);
+    font-family: inherit;
+    font-size: inherit;
+}
+
 .user-css-presentation .nav-tabs {
     border: none;
     border-bottom: 1px solid;
@@ -564,7 +581,7 @@
 
 .user-css-presentation .nav-tabs li a,
 .user-css-presentation .nav-tabs li a:hover,
-.user-css-presentation .av-tabs li.active a {
+.user-css-presentation .nav-tabs li.active a {
     border: none;
     border-radius: var(--borderRadius) var(--borderRadius) 0 0;
     font-family: inherit;
@@ -602,6 +619,14 @@
 .user-css-presentation .panel-heading h3 {
     margin-top: 0;
     border: none;
+}
+
+.user-css-presentation .panel-footer,
+.user-css-presentation .panel-bottom {
+    margin: 10px -5px -3px -5px;
+    padding: 10px 20px 13px 20px;
+    border: none;
+    vertical-align: middle;
 }
 
 .user-css-presentation .table {
@@ -1028,6 +1053,7 @@
     border-right: 1px solid;
 }
 
+.user-css-presentation .row-border-group .user-row .col-md-3,
 .user-css-presentation .row-border-group .user-row .col-md-4 {
     border-left: 1px solid;
     border-right: 1px solid;
@@ -1049,24 +1075,28 @@
     border: none;
 }
 
+.user-css-presentation .row-border-group .user-row .col-md-3:first-child,
 .user-css-presentation .row-border-group .user-row .col-md-4:first-child {
     border-left: none;
     border-top: none;
     border-bottom: none;
 }
 
-.user-css-presentation .row-border-group .user-row .col-md-4:last-child {
+.user-css-presentation .row-border-group .user-row .col-md-3:last-child,
+.user-css-presentation .row-border-group .user-row .col-md-4:first-child {
     border-right: none;
     border-top: none;
     border-bottom: none;
 }
 
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3,
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4 {
     border-top: none;
     border-left: none;
     border-right: none;
 }
 
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3,
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4 {
     border-bottom: none;
     border-left: none;
@@ -1075,10 +1105,11 @@
 
 .user-css-presentation .row-border-group .user-row .col-md-6:after,
 .user-css-presentation .row-border-group .user-row .col-md-6:before,
+.user-css-presentation .row-border-group .user-row .col-md-3:after,
+.user-css-presentation .row-border-group .user-row .col-md-3:before,
 .user-css-presentation .row-border-group .user-row .col-md-4:after,
 .user-css-presentation .row-border-group .user-row .col-md-4:before,
-.user-css-presentation .row-border-group .user-row .col-md-12:after
-{
+.user-css-presentation .row-border-group .user-row .col-md-12:after {
     content: url(https://www.worldanvil.com/themes/galaxyanvil/images/empty.gif);
     position: absolute;
 }
@@ -1087,6 +1118,10 @@
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:after, /* 2-col Middle right cell, top border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:first-child:before, /* 2-col Bottom left cell, top border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:last-child:before, /* 2-col Bottom right cell, top border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:first-child:after, /* 4-col Middle left cell, top border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:last-child:after, /* 4-col Middle right cell, top border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:first-child:before, /* 4-col Bottom left cell, top border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:last-child:before, /* 4-col Bottom right cell, top border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:first-child:after, /* 3-col Middle left cell, top border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:last-child:after, /* 3-col Middle right cell, top border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4:first-child:before, /* 3-col Bottom left cell, top border */
@@ -1103,6 +1138,10 @@
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before, /* 2-col Middle right cell, bottom border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:first-child:before, /* 2-col Top left cell, bottom border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:last-child:before, /* 2-col Top right cell, bottom border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:first-child:before, /* 4-col Middle left cell, bottom border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:last-child:before, /* 4-col Middle right cell, bottom border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:first-child:before, /* 4-col Top left cell, bottom border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:last-child:before, /* 4-col Top right cell, bottom border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:first-child:before, /* 3-col Middle left cell, bottom border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:last-child:before, /* 3-col Middle right cell, bottom border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:first-child:before, /* 3-col Top left cell, bottom border */
@@ -1117,6 +1156,10 @@
 
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:first-child:after, /* 2-col Top left cell, right border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:first-child:after, /* 2-col Bottom left cell, right border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:not(:first-child):not(:last-child):before, /* 4-col Top middle cell, right border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:not(:first-child):not(:last-child):before, /* 4-col Bottom middle cell, right border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:first-child:after, /* 4-col Top left cell, right border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:first-child:after, /* 4-col Bottom left cell, right border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:not(:first-child):not(:last-child):before, /* 3-col Top middle cell, right border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4:not(:first-child):not(:last-child):before, /* 3-col Bottom middle cell, right border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:first-child:after, /* 3-col Top left cell, right border */
@@ -1130,6 +1173,10 @@
 
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:last-child:after, /* 2-col Top right cell, left border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:last-child:after, /* 2-col Bottom right cell, left border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:not(:first-child):not(:last-child):after, /* 4-col Top middle cell, left border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:not(:first-child):not(:last-child):after, /* 4-col Bottom middle cell, left border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:last-child:after, /* 4-col Top right cell, left border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:last-child:after, /* 4-col Bottom right cell, left border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:not(:first-child):not(:last-child):after, /* 3-col Top middle cell, left border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4:not(:first-child):not(:last-child):after, /* 3-col Bottom middle cell, left border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:last-child:after, /* 3-col Top right cell, left border */
@@ -1142,6 +1189,8 @@
 }
 
 .user-css-presentation .row-border-group .user-row:only-child .col-md-6:first-child:after, /* 2-col Single row left cell, right border */
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:first-child:after, /* 4-col Single row left cell, right border */
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:not(:first-child):not(:last-child):after, /* 4-col Single row middle cell, right border */
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:first-child:after, /* 3-col Single row left cell, right border */
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:not(:first-child):not(:last-child):after /* 3-col Single row middle cell, right border */
 {
@@ -1153,6 +1202,8 @@
 }
 
 .user-css-presentation .row-border-group .user-row:only-child .col-md-6:last-child:after, /* 2-col Single row right cell, left border */
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:last-child:after, /* 4-col Single row right cell, left border */
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:not(:first-child):not(:last-child):before, /* 4-col Single row middle cell, left border */
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:last-child:after, /* 3-col Single row right cell, left border */
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:not(:first-child):not(:last-child):before /* 3-col Single row middle cell, left border */
 {
@@ -1165,6 +1216,8 @@
 
 .user-css-presentation .row-border-group .user-row:only-child .col-md-6:first-child:before,
 .user-css-presentation .row-border-group .user-row:only-child .col-md-6:last-child:before,
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:first-child:before,
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:last-child:before,
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:first-child:before,
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:last-child:before
 {
@@ -1352,7 +1405,7 @@
     box-shadow: 0 0 2px 2px var(--default9);
 }
 
-.user-css-presentation .alert-default h5:first-child {
+.user-css-presentation .alert-default h5:first-of-type {
     color: var(--default3);
 }
 
@@ -1364,7 +1417,7 @@
     box-shadow: 0 0 2px 2px var(--primary9);
 }
 
-.user-css-presentation .alert-primary h5:first-child {
+.user-css-presentation .alert-primary h5:first-of-type {
     color: var(--primary3);
 }
 
@@ -1376,11 +1429,12 @@
     box-shadow: 0 0 2px 2px var(--accent9);
 }
 
-.user-css-presentation .alert-secondary h5:first-child {
+.user-css-presentation .alert-secondary h5:first-of-type {
     color: var(--accent3);
 }
 
-.user-css-presentation .alert-info {
+.user-css-presentation .alert-info,
+.user-css-presentation .alert-blue {
     background-color: var(--info5Transparent);
     background: linear-gradient(to right, var(--info5Transparent), var(--info5), var(--info5Transparent));
     border-color: var(--info9);
@@ -1388,11 +1442,13 @@
     box-shadow: 0 0 2px 2px var(--info9);
 }
 
-.user-css-presentation .alert-info h5:first-child {
+.user-css-presentation .alert-info h5:first-of-type,
+.user-css-presentation .alert-blue h5:first-of-type {
     color: var(--info3);
 }
 
-.user-css-presentation .alert-success {
+.user-css-presentation .alert-success,
+.user-css-presentation .alert-green {
     background-color: var(--success5Transparent);
     background: linear-gradient(to right, var(--success5Transparent), var(--success5), var(--success5Transparent));
     border-color: var(--success9);
@@ -1400,11 +1456,13 @@
     box-shadow: 0 0 2px 2px var(--success9);
 }
 
-.user-css-presentation .alert-success h5:first-child {
+.user-css-presentation .alert-success h5:first-of-type,
+.user-css-presentation .alert-green h5:first-of-type {
     color: var(--success3);
 }
 
-.user-css-presentation .alert-warning {
+.user-css-presentation .alert-warning,
+.user-css-presentation .alert-yellow {
     background-color: var(--warning5Transparent);
     background: linear-gradient(to right, var(--warning5Transparent), var(--warning5), var(--warning5Transparent));
     border-color: var(--warning9);
@@ -1412,11 +1470,13 @@
     box-shadow: 0 0 2px 2px var(--warning9);
 }
 
-.user-css-presentation .alert-warning h5:first-child {
+.user-css-presentation .alert-warning h5:first-of-type,
+.user-css-presentation .alert-yellow h5:first-of-type {
     color: var(--warning3);
 }
 
-.user-css-presentation .alert-danger {
+.user-css-presentation .alert-danger,
+.user-css-presentation .alert-red {
     background-color: var(--danger5Transparent);
     background: linear-gradient(to right, var(--danger5Transparent), var(--danger5), var(--danger5Transparent));
     border-color: var(--danger9);
@@ -1424,7 +1484,8 @@
     box-shadow: 0 0 2px 2px var(--danger9);
 }
 
-.user-css-presentation .alert-danger h5:first-child {
+.user-css-presentation .alert-danger h5:first-of-type,
+.user-css-presentation .alert-red h5:first-of-type {
     color: var(--danger3);
 }
 
@@ -1474,6 +1535,16 @@
 }
 
 /* BUTTONS */
+.user-css-presentation button.close {
+    color: var(--dangerA);
+    text-shadow: 0 0 1px 1px var(--dangerATransparent);
+}
+
+.user-css-presentation button.close:hover {
+    color: var(--dangerD);
+    text-shadow: 0 0 1px 1px var(--dangerDTransparent);
+}
+
 .user-css-presentation .btn-default {
     color: var(--defaultDMuted) !important;
     background: var(--defaultATransparent) !important;
@@ -1657,7 +1728,54 @@
     color: var(--danger3Muted);
 }
 
+/* MODAL */
+.user-css-presentation .modal-dialog {
+    background-color: var(--accent3Transparent);
+    background: linear-gradient(to right, var(--accent3Transparent), var(--accent3), var(--accent3Transparent));
+    border-color: var(--accent4Transparent);
+    color: var(--accentDMuted);
+    box-shadow: 0 0 2px 2px var(--accent4Transparent);
+}
+
+.user-css-presentation .modal-dialog .text-muted {
+    color: var(--accent8Muted);
+}
+
+.user-css-presentation .modal-dialog .modal-footer,
+.user-css-presentation .modal-dialog .modal-bottom,
+.user-css-presentation .modal-dialog .modal-header {
+    background-color: var(--accent4Transparent);
+    background: linear-gradient(to right, var(--accent4Transparent), var(--accent4), var(--accent4Transparent));
+}
+
+.user-css-presentation .modal-dialog .modal-header h5 {
+    color: var(--accentDMuted);
+}
+
+.user-css-presentation .modal-dialog .modal-header small,
+.user-css-presentation .modal-dialog .modal-header .text-muted {
+    color: var(--accentCMuted);
+}
+
 /* NAV */
+.user-css-presentation .nav-pills li a {
+    color: var(--primaryD);
+}
+
+.user-css-presentation .nav-pills li a:hover {
+    background: var(--primaryATransparent);
+    background: linear-gradient(to right, var(--primary9Transparent), var(--primaryATransparent), var(--primary9Transparent));
+    color: var(--primaryDMuted);
+    box-shadow: 0 0 1px 1px var(--primary9Transparent);
+}
+
+.user-css-presentation .nav-pills li.active a {
+    background: var(--primaryC);
+    background: linear-gradient(to right, var(--primaryA), var(--primaryC), var(--primaryA));
+    color: var(--primary3Muted);
+    box-shadow: 0 0 1px 1px var(--primaryA);
+}
+
 .user-css-presentation .nav-tabs li a {
     background: var(--accentATransparent);
     color: var(--accentDMuted);
@@ -1726,14 +1844,16 @@
 .user-css-presentation .panel {
     background-color: var(--default3Transparent);
     background: linear-gradient(to right, var(--default3Transparent), var(--default3), var(--default3Transparent));
-    border-color: var(--default4Transparent);
+    border-color: var(--default7Transparent);
     color: var(--defaultDMuted);
-    box-shadow: 0 0 2px 2px var(--default4Transparent);
+    box-shadow: 0 0 2px 2px var(--default7Transparent);
 }
 
-.user-css-presentation .panel .panel-heading {
-    background-color: var(--default5Transparent);
-    background: linear-gradient(to right, var(--default5Transparent), var(--default5), var(--default5Transparent));
+.user-css-presentation .panel .panel-heading,
+.user-css-presentation .panel .panel-footer,
+.user-css-presentation .panel .panel-bottom {
+    background-color: var(--default7Transparent);
+    background: linear-gradient(to right, var(--default7Transparent), var(--default7), var(--default7Transparent));
 }
 
 .user-css-presentation .panel .panel-heading h3 {
@@ -1748,14 +1868,15 @@
 .user-css-presentation .panel-default {
     background-color: var(--accent3Transparent);
     background: linear-gradient(to right, var(--accent3Transparent), var(--accent3), var(--accent3Transparent));
-    border-color: var(--accent4Transparent);
+    border-color: var(--accent7Transparent);
     color: var(--accentDMuted);
-    box-shadow: 0 0 2px 2px var(--accent4Transparent);
+    box-shadow: 0 0 2px 2px var(--accent7Transparent);
 }
 
-.user-css-presentation .panel-default .panel-heading {
-    background-color: var(--accent4Transparent);
-    background: linear-gradient(to right, var(--accent4Transparent), var(--accent4), var(--accent4Transparent));
+.user-css-presentation .panel-default .panel-heading,
+.user-css-presentation .panel-default .panel-bottom {
+    background-color: var(--accent7Transparent);
+    background: linear-gradient(to right, var(--accent7Transparent), var(--accent7), var(--accent7Transparent));
 }
 
 .user-css-presentation .panel-default .panel-heading h3 {
@@ -1771,9 +1892,9 @@
 .user-css-presentation .panel-npcsheet {
     background-color: var(--primary3Transparent);
     background: linear-gradient(to right, var(--primary3Transparent), var(--primary3), var(--primary3Transparent));
-    border-color: var(--primary4Transparent);
+    border-color: var(--primary7Transparent);
     color: var(--primaryDMuted);
-    box-shadow: 0 0 2px 2px var(--primary4Transparent);
+    box-shadow: 0 0 2px 2px var(--primary7Transparent);
 }
 
 .user-css-presentation .panel-primary hr,
@@ -1781,9 +1902,10 @@
     border-color: var(--primaryA);
 }
 
-.user-css-presentation .panel-primary .panel-heading {
-    background-color: var(--primary4Transparent);
-    background: linear-gradient(to right, var(--primary4Transparent), var(--primary4), var(--primary4Transparent));
+.user-css-presentation .panel-primary .panel-heading,
+.user-css-presentation .panel-primary .panel-bottom {
+    background-color: var(--primary7Transparent);
+    background: linear-gradient(to right, var(--primary7Transparent), var(--primary7), var(--primary7Transparent));
 }
 
 .user-css-presentation .panel-primary .panel-heading h3 {
@@ -1814,8 +1936,8 @@
 
 /* ROW BORDER GROUP */
 .user-css-presentation .row-border-group .user-row .col-md-6,
-.user-css-presentation .row-border-group .user-row .col-md-4
-{
+.user-css-presentation .row-border-group .user-row .col-md-3,
+.user-css-presentation .row-border-group .user-row .col-md-4 {
     border-color: var(--accentA);
 }
 
@@ -1823,6 +1945,10 @@
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:first-child:before,
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:first-child:before,
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:first-child:before,
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:first-child:before, /* 4-col Top left cell, bottom border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:first-child:after, /* 4-col Middle left cell, top border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:first-child:before, /* 4-col Middle left cell, bottom border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:first-child:before, /* 4-col Bottom left cell, top border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:first-child:before, /* 3-col Top left cell, bottom border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:first-child:after, /* 3-col Middle left cell, top border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:first-child:before, /* 3-col Middle left cell, bottom border */
@@ -1835,6 +1961,10 @@
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-6:last-child:before,
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:last-child:before,
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:last-child:before,
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:last-child:before, /* 4-col Top right cell, bottom border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:last-child:after, /* 4-col Middle right cell, top border */
+.user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-3:last-child:before, /* 4-col Middle right cell, bottom border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:last-child:before, /* 4-col Bottom right cell, top border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:last-child:before, /* 3-col Top right cell, bottom border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:last-child:after, /* 3-col Middle right cell, top border */
 .user-css-presentation .row-border-group .user-row:not(:first-child):not(:last-child) .col-md-4:last-child:before, /* 3-col Middle right cell, bottom border */
@@ -1845,6 +1975,10 @@
 
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:first-child:after,
 .user-css-presentation .row-border-group .user-row:first-child .col-md-6:last-child:after,
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:first-child:after, /* 4-col Top left cell, right border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:not(:first-child):not(:last-child):after, /* 4-col Top middle cell, left border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:not(:first-child):not(:last-child):before, /* 4-col Top middle cell, right border */
+.user-css-presentation .row-border-group .user-row:first-child .col-md-3:last-child:after, /* 4-col Top right cell, left border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:first-child:after, /* 3-col Top left cell, right border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:not(:first-child):not(:last-child):after, /* 3-col Top middle cell, left border */
 .user-css-presentation .row-border-group .user-row:first-child .col-md-4:not(:first-child):not(:last-child):before, /* 3-col Top middle cell, right border */
@@ -1855,6 +1989,10 @@
 
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:first-child:after,
 .user-css-presentation .row-border-group .user-row:last-child .col-md-6:last-child:after,
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:first-child:after, /* 4-col Bottom left cell, right border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:not(:first-child):not(:last-child):after, /* 4-col Bottom middle cell, left border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:not(:first-child):not(:last-child):before, /* 4-col Bottom middle cell, right border */
+.user-css-presentation .row-border-group .user-row:last-child .col-md-3:last-child:after, /* 4-col Bottom right cell, left border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4:first-child:after, /* 3-col Bottom left cell, right border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4:not(:first-child):not(:last-child):after, /* 3-col Bottom middle cell, left border */
 .user-css-presentation .row-border-group .user-row:last-child .col-md-4:not(:first-child):not(:last-child):before, /* 3-col Bottom middle cell, right border */
@@ -1865,6 +2003,10 @@
 
 .user-css-presentation .row-border-group .user-row:only-child .col-md-6:first-child:after,
 .user-css-presentation .row-border-group .user-row:only-child .col-md-6:last-child:after,
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:first-child:after, /* 4-col Single row left cell, right border */
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:not(:first-child):not(:last-child):after, /* 4-col Single row middle cell, right border */
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:last-child:after, /* 4-col Single row right cell, left border */
+.user-css-presentation .row-border-group .user-row:only-child .col-md-3:not(:first-child):not(:last-child):before, /* 4-col Single row middle cell, left border */
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:first-child:after, /* 3-col Single row left cell, right border */
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:not(:first-child):not(:last-child):after, /* 3-col Single row middle cell, right border */
 .user-css-presentation .row-border-group .user-row:only-child .col-md-4:last-child:after, /* 3-col Single row right cell, left border */
@@ -1924,9 +2066,49 @@
     color: var(--accentDMuted);
 }
 
-.user-css-presentation .table tr:hover td {
+.user-css-presentation .table tr:hover td:not(.info, .success, .warning, .danger) {
     background: var(--primary8Transparent);
     color: var(--primaryDMuted);
+}
+
+.user-css-presentation .table tr td.info {
+    background: var(--info3Transparent);
+    color: var(--infoDMuted);
+}
+
+.user-css-presentation .table-striped tr:nth-child(odd) td.info {
+    background: var(--info4Transparent);
+    color: var(--infoDMuted);
+}
+
+.user-css-presentation .table tr td.success {
+    background: var(--success3Transparent);
+    color: var(--successDMuted);
+}
+
+.user-css-presentation .table-striped tr:nth-child(odd) td.success {
+    background: var(--success4Transparent);
+    color: var(--successDMuted);
+}
+
+.user-css-presentation .table tr td.warning {
+    background: var(--warning3Transparent);
+    color: var(--warningDMuted);
+}
+
+.user-css-presentation .table-striped tr:nth-child(odd) td.warning {
+    background: var(--warning4Transparent);
+    color: var(--warningDMuted);
+}
+
+.user-css-presentation .table tr td.danger {
+    background: var(--danger3Transparent);
+    color: var(--dangerDMuted);
+}
+
+.user-css-presentation .table-striped tr:nth-child(odd) td.danger {
+    background: var(--danger4Transparent);
+    color: var(--dangerDMuted);
 }
 
 /* TEXT */
@@ -2024,7 +2206,6 @@
 .tooltipster-base.tooltipster-sidetip.tooltipster-light.tooltipster-right .tooltipster-arrow-uncropped .tooltipster-arrow-background {
     border-right-color: var(--accent3Muted);
 }
-
 
 
 /* CODE/PRE */
@@ -2316,3 +2497,18 @@
 .user-css-presentation .text-danger {
     color: var(--dangerD);
 }
+
+/* CALENDARS (Has to override alot of stuff so it's last) */
+.user-css-presentation #display-calendar-presentation.panel {
+    background: none;
+    box-shadow: none;
+}
+
+.user-css-presentation #display-calendar-presentation.panel .table-hover tr:hover td:not(.info, .success, .warning, .danger) {
+    background: var(--default3Transparent);
+    color: var(--defaultDMuted);
+}
+
+.user-css-presentation #display-calendar-presentation.panel .table-hover tr td:hover {
+    background: var(--primary8Transparent);
+    color: var(--primaryDMuted);

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1224,6 +1224,46 @@
     display: none;
 }
 
+.user-css-presentation .donut-chart {
+    display: flex!important;
+    height: 110px;
+    margin: 5px;
+    padding: 5px;
+    background: none;
+    border-radius: var(--borderRadius);
+    border: none;
+}
+
+.user-css-presentation .donut-values {
+    margin-left: 20px;
+    font-size: 1.4rem;
+    display: flex;
+    flex-flow: column wrap;
+}
+
+.user-css-presentation .donut-values p {
+    margin: 0 10px 0 0;
+    padding: 0;
+}
+
+.user-css-presentation .donut {
+    border-radius: 50%;
+    width: 100px;
+    height: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.user-css-presentation .donut:before {
+    content: url(.);
+    width: 60px;
+    height: 60px;
+    position: absolute;
+    border-radius: 50%;
+    margin: 20px;
+}
+
 /* LAYOUT - TOOLTIPSTER */
 .tooltipster-base.tooltipster-sidetip.tooltipster-light .tooltipster-box {
     border-radius: var(--borderRadius);
@@ -1644,6 +1684,27 @@
 
 .user-css-presentation .comment-box-reply {
     border-color: var(--defaultAMuted);
+}
+
+/* DONUT CHART */
+.user-css-presentation .donut-chart {
+    background-color: var(--primary5Transparent);
+    background: linear-gradient(to right, var(--primary5Transparent), var(--primary5), var(--primary5Transparent));
+    color: var(--primaryDMuted);
+    box-shadow: 0 0 2px 2px var(--primaryATransparent);
+}
+
+.user-css-presentation .donut {
+    box-shadow: 0px 0px 5px 2px var(--primary2Transparent),
+                inset 0px 0px 2px 2px var(--primary2Transparent);
+}
+
+.user-css-presentation .donut:before {
+    box-shadow: inset 0px 0px 2px 2px var(--primary2Transparent);
+}
+
+.user-css-presentation .donut-text {
+    color: var(--primaryD);
 }
 
 /* LABELS */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -2573,3 +2573,4 @@
 .user-css-presentation #display-calendar-presentation.panel .table-hover tr td:hover {
     background: var(--primary8Transparent);
     color: var(--primaryDMuted);
+}


### PR DESCRIPTION
This is a hard reset of the git branch on my end because I managed to break it. Here's a summarized list of everything in the git difference:

Changes include:
- General improvements to layout and design.
- Additional col sizes are now supported in `.row-border-group` - `col-md-3`, `col-md-4` (`[col3]`), `col-md-6` (`[col]`), and `col-md-12` are the currently supported sizes.
- Alert classes now have color-name variants due to new WorldAnvil restrictions on certain `alert-` class names.
- `panel-` color variants now exist for info, success, warning, and danger color schemes.
- `panel-bottom` now exists as a usable and customizable replacement of `panel-footer` for container use.
- Panel borders and heading/footer backgrounds now use brighter colors for better contrast.
- Basic formatting and theming updates for `modal` classes.
- `modal-bottom` added as a usable and customizable replacement of `modal-footer` for container use.
- Close buttons now have proper formatting and color.
- Navigational buttons have had a theme application update.
- Tables now support theming for info, success, warning, and danger classes.
- Basic theming and layout support for WorldAnvil calendars.
- CSS framework for adding donut pie charts added. Thanks to TJ for the original CSS this was adapted from.