### PR TITLE
Galaxyanvil 1.5.0

### DIFF
--- a/themes/galaxyanvil/ABOUT.MD
+++ b/themes/galaxyanvil/ABOUT.MD
@@ -1,8 +1,21 @@
 # GalaxyAnvil
-Version: 1.3.0
+Version: 1.5.0
 
 A theme for WorldAnvil, created by SierraKomodo.
 
-Master branch: https://github.com/SierraKomodo/worldanvil-templates/tree/GalaxyAnvil
+Master branch: [`master` branch | GalaxyAnvil on GitHub](https://github.com/SierraKomodo/worldanvil-templates/tree/master/themes/galaxyanvil)
 
-See the theme in action here: https://www.worldanvil.com/w/galaxies-end-sierrakomodo/a/scratchpad-article
+Inline branch: [`inline` branch | GalaxyAnvil on GitHub](https://github.com/SierraKomodo/worldanvil-templates/tree/inline/themes/galaxyanvil)
+
+See the theme in action here:
+ - [GalaxyAnvil Theme Preview | GalaxyAnvil on WorldAnvil](https://www.worldanvil.com/w/galaxyanvil-sierrakomodo/a/galaxyanvil-theme-preview-article)
+ - [GalaxyAnvil Inline Theme Preview | Galaxies End on WorldAnvil](https://www.worldanvil.com/w/galaxies-end-sierrakomodo/a/galaxyanvil-inline-theme-preview-article)
+
+## Master Branch
+The `master `branch is a version of GalaxyAnvil intended for WorldAnvil to host as a selectable theme. This version includes CSS tags and code that is blocked or banned in custom CSS boxes and should not be copy+pasted into the custom CSS box of your world, else the theme will break. You can use GalaxyAnvil on WorldAnvil for free by selecting World Settings > Styling in the WorldAnvil Dashboard, and choosing 'GalaxyAnvil' in the Theme selection dropdown.
+
+## Inline Branch
+The `inline` branch is a version of GalaxyAnvil intended for power users to use in place of the selectable theme. To use this version, navigate to World Settings > Styling in the WorldAnvil Dashboard, select the CSS tab, then copy and paste the contents of `themes\galaxyanvil\css\style.css` into the Presentation Cascade Stylesheets (CSS) box. You can then modify the CSS as you see fit to match your world.
+
+## Galaxies End Branch
+The `galaxies-end` branch is the version of GalaxyAnvil inline specifically built for use in the Galaxies End WorldAnvil universe. This includes the custom color schemes used for different sections of Galaxies End, as well as additional personal tweaks added by SierraKomodo to better fit the Galaxies End universe that were deemed not fitting of GalaxyAnvil as a whole.

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [1.5.0] - UNRELEASED
+### Added
+ - Support for WorldAnvil's `imgblock` bbcode.
+
 ### Changed
  - Tweaked comment box font sizes to be more inline with the rest of the theme's sizes.
 

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.5.0] - UNRELEASED
+## [1.5.0] - 2021-10-13
 ### Added
  - Support for WorldAnvil's `imgblock` bbcode.
  - `inline` code branch for power users. See the Inline section of `ABOUT.MD` for details.

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+
+## [1.5.0] - UNRELEASED
+### Changed
+ - Tweaked comment box font sizes to be more inline with the rest of the theme's sizes.
+
+
+## [1.4.0]
 ### Added
  - Support for WorldAnvil's new world presentation front page
  - Support for Organization Tree

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.0] - UNRELEASED
 ### Added
  - Support for WorldAnvil's `imgblock` bbcode.
+ - `inline` code branch for power users. See the Inline section of `ABOUT.MD` for details.
+ - `galaxies-end` code branch as a clone of the Galaxies End version of GalaxyAnvil.
 
 ### Changed
  - Tweaked comment box font sizes to be more inline with the rest of the theme's sizes.
+ - Updated `ABOUT.MD`.
 
 
 ## [1.4.0]

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Support for WorldAnvil's `imgblock` bbcode.
  - `inline` code branch for power users. See the Inline section of `ABOUT.MD` for details.
  - `galaxies-end` code branch as a clone of the Galaxies End version of GalaxyAnvil.
+ - `flex-block` class, which can be used to wrap `[tagged:tag-name|block]` bbcode to automatically size and organize article blocks.
+    - Example code: `[container:flex-block][tagged:matari|block|Matari][/container]`
+    - Example with `flex-block` container: [Example with class](https://i.imgur.com/M6SfDKH.jpeg)
+    - Example without `flex-block` container: [Example without class](https://i.imgur.com/zI7vXJI.jpeg)
 
 ### Changed
  - Tweaked comment box font sizes to be more inline with the rest of the theme's sizes.

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -750,6 +750,10 @@
     padding-left: 5px;
 }
 
+.user-css-presentation .comment-box .comment-box-content {
+    font-size: inherit;
+}
+
 .user-css-presentation .comment-box-author {
     font-family: Mina, serif;
     font-size: 2rem;
@@ -770,10 +774,6 @@
     border-top: 1px solid;
     margin-top: 20px;
     padding-top: 10px;
-}
-
-.user-css-presentation .comment-box p {
-    font-size: 1.2em;
 }
 
 .user-css-presentation .cover,

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -790,6 +790,35 @@
     text-transform: initial;
 }
 
+.user-css-presentation .image-panel {
+    background: none;
+    border: none;
+    border-radius: var(--borderRadius);
+    margin-bottom: 20px;
+    padding: 0;
+}
+
+.user-css-presentation .image-panel .cover {
+    background: none;
+    margin: 0;
+    overflow: visible;
+}
+
+.user-css-presentation .image-panel .cover .user-css-image-thumbnail {
+    border-radius: var(--borderRadius) var(--borderRadius) 0 0;
+    margin: 0;
+}
+
+.user-css-presentation .image-panel .header {
+    padding: 10px 5px 5px 5px;
+}
+
+.user-css-presentation .image-panel .subheading {
+    margin: 0;
+    padding: 0;
+    text-align: center;
+}
+
 .user-css-presentation .map-box {
     border-radius: var(--borderRadius);
     padding: 0;
@@ -1705,6 +1734,46 @@
 
 .user-css-presentation .donut-text {
     color: var(--primaryD);
+}
+
+/* IMAGE BLOCKS */
+.user-css-presentation .image-panel {
+    border-color: var(--primary7Transparent);
+    color: var(--primaryDMuted);
+    box-shadow: 0 0 2px 2px var(--primary7Transparent);
+}
+
+.user-css-presentation .image-panel .cover .user-css-image-thumbnail {
+    background-color: var(--accent5Transparent);
+    background: linear-gradient(to right, var(--accent5Transparent), var(--accent5), var(--accent5Transparent));
+    box-shadow: none;
+}
+
+.user-css-presentation .image-panel .header {
+    background-color: var(--primary7);
+    background: linear-gradient(to right, var(--primary7Transparent), var(--primary7), var(--primary7Transparent));
+}
+
+.user-css-presentation .image-panel .header h5 {
+    color: var(--primaryDMuted);
+}
+
+.user-css-presentation .image-panel .subheading {
+    background-color: var(--primary3Transparent);
+    background: linear-gradient(to right, var(--primary3Transparent), var(--primary3), var(--primary3Transparent));
+    color: var(--primaryDMuted);
+}
+
+.user-css-presentation .image-panel .subheading .artist-credits {
+    background: none;
+}
+
+.user-css-presentation .image-panel .subheading .artist-credits small {
+    color: var(--primaryCMuted);
+}
+
+.user-css-presentation .image-panel .subheading .image-excerpt {
+    color: var(--primaryDMuted);
 }
 
 /* LABELS */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1050,7 +1050,13 @@
     display: block;
 }
 
-.user-css-presentation .glossary-block {
+.user-css-presentation .flex-block .tagged-articles-list .tagged-articles-list-header {
+    width: 100%;
+    text-align: left;
+}
+
+.user-css-presentation .glossary-block,
+.user-css-presentation .flex-block .tagged-articles-list {
     display: flex;
     flex-flow: row wrap;
     margin-left: -7.5px;
@@ -1058,17 +1064,20 @@
     text-align: center;
 }
 
-.user-css-presentation .glossary-block .article-panel {
+.user-css-presentation .glossary-block .article-panel,
+.user-css-presentation .flex-block .tagged-articles-list .article-panel {
     margin-left: 7.5px;
     margin-right: 7.5px;
     flex: 0 1 calc(33.3% - 15px);
 }
 
-.user-css-presentation .glossary-block .article-panel a {
+.user-css-presentation .glossary-block .article-panel a,
+.user-css-presentation .flex-block .tagged-articles-list .article-panel a {
     height: 100%;
 }
 
-.user-css-presentation .glossary-block .article-panel .cover {
+.user-css-presentation .glossary-block .article-panel .cover,
+.user-css-presentation .flex-block .tagged-articles-list .article-panel .cover {
     /* display: none; */
     min-height: 100px;
 }


### PR DESCRIPTION
## Changelog
### Added
 - Support for WorldAnvil's `imgblock` bbcode.
 - `inline` code branch for power users. See the Inline section of `ABOUT.MD` for details.
 - `galaxies-end` code branch as a clone of the Galaxies End version of GalaxyAnvil.
 - `flex-block` class, which can be used to wrap `[tagged:tag-name|block]` bbcode to automatically size and organize article blocks.
    - Example code: `[container:flex-block][tagged:matari|block|Matari][/container]`
    - Example with `flex-block` container: [Example with class](https://i.imgur.com/M6SfDKH.jpeg)
    - Example without `flex-block` container: [Example without class](https://i.imgur.com/zI7vXJI.jpeg)

### Changed
 - Tweaked comment box font sizes to be more inline with the rest of the theme's sizes.
 - Updated `ABOUT.MD`.