### PR TITLE
[call_of_cthulhu] Fixes for input fields

### DIFF
--- a/block-system-2.0/call_of_cthulhu/character-sheet/call_of_cthulhu_sheet.css
+++ b/block-system-2.0/call_of_cthulhu/character-sheet/call_of_cthulhu_sheet.css
@@ -153,7 +153,9 @@ th {
 }
 
 .form-control {
-    padding: 2px 2px 2px 4px
+    padding: 2px 2px 2px 4px;
+    color: #404040!important;
+    background: transparent!important;
 }
 
 .al {


### PR DESCRIPTION
## MOD :
- call_of_cthulhu/character-sheet/call_of_cthulhu_sheet.css : modified text/background colors

Currently when Terror from the Deep theme is selected, the values of the fields are barely visible (light text color) and when editing the fields, the background changes to black.
Transparent background + black text = pretty fields.
Seems to work for all themes.
