### PR TITLE
GalaxyAnvil 1.6.0

### DIFF
--- a/themes/galaxyanvil/ABOUT.MD
+++ b/themes/galaxyanvil/ABOUT.MD
@@ -1,5 +1,5 @@
 # GalaxyAnvil
-Version: 1.5.0
+Version: 1.6.0
 
 A theme for WorldAnvil, created by SierraKomodo.
 

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.6.0] - UNRELEASED
+
+
 ## [1.5.0] - 2021-10-13
 ### Added
  - Support for WorldAnvil's `imgblock` bbcode.

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.6.0] - UNRELEASED
+## [1.6.0] - 2024-10-15
 ### Added
  - Support for WorldAnvil's `articletoc` bbcode.
    - Additional styling when used within `.panel-toc .panel-body` containers.

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.6.0] - UNRELEASED
 ### Fixed
  - Fixes the pronunciation text not inheriting the article title's font family.
+ - Fixes navigation tab colors and contrast (These are tab buttons primarily visible in the article metadata footer).
 
 
 ## [1.5.0] - 2021-10-13

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [1.6.0] - UNRELEASED
+### Added
+ - Support for WorldAnvil's `articletoc` bbcode.
+   - Additional styling when used within `.panel-toc .panel-body` containers.
+
 ### Fixed
  - Fixes the pronunciation text not inheriting the article title's font family.
  - Fixes navigation tab colors and contrast (These are tab buttons primarily visible in the article metadata footer).

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [1.6.0] - UNRELEASED
+### Fixed
+ - Fixes the pronunciation text not inheriting the article title's font family.
 
 
 ## [1.5.0] - 2021-10-13

--- a/themes/galaxyanvil/CHANGELOG.MD
+++ b/themes/galaxyanvil/CHANGELOG.MD
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixes the pronunciation text not inheriting the article title's font family.
  - Fixes navigation tab colors and contrast (These are tab buttons primarily visible in the article metadata footer).
  - Fixes the presentation page being uninteractable once the World Codex is opened.
+ - Fixes the rendering of cell borders for the right-hand middle cells in 3-column rows under `.row-border-group`.
 
 
 ## [1.5.0] - 2021-10-13

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -2071,7 +2071,8 @@
 }
 
 /* PANELS */
-.user-css-presentation .panel {
+.user-css-presentation .panel,
+.user-css-presentation .panel-secondary {
     background-color: var(--default3Transparent);
     background: linear-gradient(to right, var(--default3Transparent), var(--default3), var(--default3Transparent));
     border-color: var(--default7Transparent);
@@ -2081,17 +2082,23 @@
 
 .user-css-presentation .panel .panel-heading,
 .user-css-presentation .panel .panel-footer,
-.user-css-presentation .panel .panel-bottom {
+.user-css-presentation .panel .panel-bottom,
+.user-css-presentation .panel-secondary .panel-heading,
+.user-css-presentation .panel-secondary .panel-footer,
+.user-css-presentation .panel-secondary .panel-bottom {
     background-color: var(--default7Transparent);
     background: linear-gradient(to right, var(--default7Transparent), var(--default7), var(--default7Transparent));
 }
 
-.user-css-presentation .panel .panel-heading h3 {
+.user-css-presentation .panel .panel-heading h3,
+.user-css-presentation .panel-secondary .panel-heading h3 {
     color: var(--defaultDMuted);
 }
 
 .user-css-presentation .panel .panel-heading small,
-.user-css-presentation .panel .panel-heading .text-muted {
+.user-css-presentation .panel .panel-heading .text-muted,
+.user-css-presentation .panel-secondary .panel-heading small,
+.user-css-presentation .panel-secondary .panel-heading .text-muted {
     color: var(--defaultCMuted);
 }
 
@@ -2145,6 +2152,114 @@
 .user-css-presentation .panel-primary .panel-heading small,
 .user-css-presentation .panel-primary .panel-heading .text-muted {
     color: var(--primaryCMuted);
+}
+
+.user-css-presentation .panel-info {
+    background-color: var(--info3Transparent);
+    background: linear-gradient(to right, var(--info3Transparent), var(--info3), var(--info3Transparent));
+    border-color: var(--info7Transparent);
+    color: var(--infoDMuted);
+    box-shadow: 0 0 2px 2px var(--info7Transparent);
+}
+
+.user-css-presentation .panel-info hr {
+    border-color: var(--infoA);
+}
+
+.user-css-presentation .panel-info .panel-heading,
+.user-css-presentation .panel-info .panel-bottom {
+    background-color: var(--info7Transparent);
+    background: linear-gradient(to right, var(--info7Transparent), var(--info7), var(--info7Transparent));
+}
+
+.user-css-presentation .panel-info .panel-heading h3 {
+    color: var(--infoDMuted);
+}
+
+.user-css-presentation .panel-info .panel-heading small,
+.user-css-presentation .panel-info .panel-heading .text-muted {
+    color: var(--infoCMuted);
+}
+
+.user-css-presentation .panel-success {
+    background-color: var(--success3Transparent);
+    background: linear-gradient(to right, var(--success3Transparent), var(--success3), var(--success3Transparent));
+    border-color: var(--success7Transparent);
+    color: var(--successDMuted);
+    box-shadow: 0 0 2px 2px var(--success7Transparent);
+}
+
+.user-css-presentation .panel-success hr {
+    border-color: var(--successA);
+}
+
+.user-css-presentation .panel-success .panel-heading,
+.user-css-presentation .panel-success .panel-bottom {
+    background-color: var(--success7Transparent);
+    background: linear-gradient(to right, var(--success7Transparent), var(--success7), var(--success7Transparent));
+}
+
+.user-css-presentation .panel-success .panel-heading h3 {
+    color: var(--successDMuted);
+}
+
+.user-css-presentation .panel-success .panel-heading small,
+.user-css-presentation .panel-success .panel-heading .text-muted {
+    color: var(--successCMuted);
+}
+
+.user-css-presentation .panel-warning {
+    background-color: var(--warning3Transparent);
+    background: linear-gradient(to right, var(--warning3Transparent), var(--warning3), var(--warning3Transparent));
+    border-color: var(--warning7Transparent);
+    color: var(--warningDMuted);
+    box-shadow: 0 0 2px 2px var(--warning7Transparent);
+}
+
+.user-css-presentation .panel-warning hr {
+    border-color: var(--warningA);
+}
+
+.user-css-presentation .panel-warning .panel-heading,
+.user-css-presentation .panel-warning .panel-bottom {
+    background-color: var(--warning7Transparent);
+    background: linear-gradient(to right, var(--warning7Transparent), var(--warning7), var(--warning7Transparent));
+}
+
+.user-css-presentation .panel-warning .panel-heading h3 {
+    color: var(--warningDMuted);
+}
+
+.user-css-presentation .panel-warning .panel-heading small,
+.user-css-presentation .panel-warning .panel-heading .text-muted {
+    color: var(--warningCMuted);
+}
+
+.user-css-presentation .panel-danger {
+    background-color: var(--danger3Transparent);
+    background: linear-gradient(to right, var(--danger3Transparent), var(--danger3), var(--danger3Transparent));
+    border-color: var(--danger7Transparent);
+    color: var(--dangerDMuted);
+    box-shadow: 0 0 2px 2px var(--danger7Transparent);
+}
+
+.user-css-presentation .panel-danger hr {
+    border-color: var(--dangerA);
+}
+
+.user-css-presentation .panel-danger .panel-heading,
+.user-css-presentation .panel-danger .panel-bottom {
+    background-color: var(--danger7Transparent);
+    background: linear-gradient(to right, var(--danger7Transparent), var(--danger7), var(--danger7Transparent));
+}
+
+.user-css-presentation .panel-danger .panel-heading h3 {
+    color: var(--dangerDMuted);
+}
+
+.user-css-presentation .panel-danger .panel-heading small,
+.user-css-presentation .panel-danger .panel-heading .text-muted {
+    color: var(--dangerCMuted);
 }
 
 .user-css-presentation .panel-greatgm {

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1180,7 +1180,7 @@
 }
 
 .user-css-presentation .row-border-group .user-row .col-md-3:last-child,
-.user-css-presentation .row-border-group .user-row .col-md-4:first-child {
+.user-css-presentation .row-border-group .user-row .col-md-4:last-child {
     border-right: none;
     border-top: none;
     border-bottom: none;

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1050,6 +1050,60 @@
     cursor: default;
 }
 
+/* LAYOUT - WORLDANVIL CLASSES - ARTICLETOC */
+.user-css-presentation div.articletoc {
+    background: none;
+    border: none;
+    border-radius: var(--borderRadius);
+    margin-bottom: 20px;
+    padding: 3px 5px;
+}
+
+.user-css-presentation div.articletoc .article-toc-link {
+    border: none;
+    margin: -3px -5px;
+    padding: 5px;
+    transition: none;
+}
+
+.user-css-presentation .panel-toc div.articletoc {
+    border-radius: unset;
+    display: block;
+    margin: -22px -20px -15px 0;
+    padding: 0;
+}
+
+.user-css-presentation .panel-toc div.articletoc .article-toc-link {
+    margin-left: -20px;
+    padding-bottom: 5px;
+    padding-right: 1rem;
+}
+
+.user-css-presentation div.articletoc .article-toc-link.article-toc-indent-0,
+.user-css-presentation .panel-toc div.articletoc .article-toc-link.article-toc-indent-0 {
+    padding-left: 1rem;
+}
+
+.user-css-presentation div.articletoc .article-toc-link.article-toc-indent-1,
+.user-css-presentation .panel-toc div.articletoc .article-toc-link.article-toc-indent-1 {
+    padding-left: 2rem;
+}
+
+.user-css-presentation div.articletoc .article-toc-link.article-toc-indent-2,
+.user-css-presentation .panel-toc div.articletoc .article-toc-link.article-toc-indent-2 {
+    padding-left: 3rem;
+}
+
+.user-css-presentation div.articletoc .article-toc-link.article-toc-indent-3,
+.user-css-presentation .panel-toc div.articletoc .article-toc-link.article-toc-indent-3 {
+    padding-left: 4rem;
+}
+
+.user-css-presentation div.articletoc .article-toc-link.article-toc-indent-4,
+.user-css-presentation .panel-toc div.articletoc .article-toc-link.article-toc-indent-4 {
+    padding-left: 5rem;
+}
+
 /* LAYOUT - CUSTOM CLASSES */
 .user-css-presentation .block {
     display: block;
@@ -2624,6 +2678,35 @@
 .user-css-presentation .timeline li.milestone a.label-default {
     background: var(--tlBackgroundTag);
     color: var(--tlColorTag);
+}
+
+/* ARTICLETOC */
+.user-css-presentation div.articletoc {
+    background-color: var(--primary3Transparent);
+    background: linear-gradient(
+        to right,
+        var(--primary3Transparent),
+        var(--primary3),
+        var(--primary3Transparent)
+    );
+    border-color: var(--primary7Transparent);
+    color: var(--primaryDMuted);
+    box-shadow: 0 0 2px 2px var(--primary7Transparent);
+}
+
+.user-css-presentation div.articletoc .article-toc-link:hover {
+    background-image: linear-gradient(
+        to right,
+        var(--primary3Transparent),
+        var(--primary5),
+        var(--primary3Transparent)
+    )
+}
+
+.user-css-presentation .panel-toc div.articletoc {
+    background: none;
+    border: none;
+    box-shadow: none;
 }
 
 /* TEXT */

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1563,6 +1563,7 @@
 }
 
 /* ALERTS */
+.user-css-presentation .alert,
 .user-css-presentation .alert-default {
     background-color: var(--default5Transparent);
     background: linear-gradient(to right, var(--default5Transparent), var(--default5), var(--default5Transparent));
@@ -1571,6 +1572,7 @@
     box-shadow: 0 0 2px 2px var(--default9);
 }
 
+.user-css-presentation .alert h5:first-of-type,
 .user-css-presentation .alert-default h5:first-of-type {
     color: var(--default3);
 }

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1400,6 +1400,14 @@
 }
 
 
+/* BACK TO TOP */
+.user-css-presentation .backtotop-button {
+    border: none;
+    border-top-left-radius: var(--borderRadiusSmall);
+    border-bottom-left-radius: var(--borderRadiusSmall);
+}
+
+
 /* THEME APPLICATION */
 .user-css-presentation {
     background-color: black;
@@ -2898,6 +2906,20 @@
     background-color: var(--default7Transparent);
     background: linear-gradient(to right, var(--default7Transparent), var(--default7), var(--default7Transparent));
     color: var(--defaultDMuted);
+}
+
+
+/* BACK TO TOP */
+.user-css-presentation .backtotop-button {
+    background-color: var(--accent5Transparent);
+    box-shadow: 0 0 2px 2px var(--accent5Transparent);
+    color: var(--accentDMuted);
+}
+
+.user-css-presentation .backtotop-button:hover {
+    background-color: var(--accentDTransparent);
+    box-shadow: 0 0 2px 2px var(--accentDTransparent);
+    color: var(--accent5Muted);
 }
 
 

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -1,6 +1,6 @@
 /*
  * GalaxyAnvil - A theme for WorldAnvil, created by SierraKomodo
- * Version 1.5.0
+ * Version 1.6.0
  * https://github.com/SierraKomodo/worldanvil-templates/tree/GalaxyAnvil
  */
 

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -579,9 +579,9 @@
     position: initial;
 }
 
-.user-css-presentation .nav-tabs li a,
-.user-css-presentation .nav-tabs li a:hover,
-.user-css-presentation .nav-tabs li.active a {
+.user-css-presentation .nav-tabs li.nav-item a.nav-link,
+.user-css-presentation .nav-tabs li.nav-item a.nav-link:hover,
+.user-css-presentation .nav-tabs li.active a.nav-link {
     border: none;
     border-radius: var(--borderRadius) var(--borderRadius) 0 0;
     font-family: inherit;
@@ -591,7 +591,8 @@
     text-transform: uppercase;
 }
 
-.user-css-presentation .nav-tabs li.active a {
+.user-css-presentation .nav-tabs li.active a.nav-link,
+.user-css-presentation .nav-tabs li.active a.nav-link:hover {
     border: 1px solid;
     border-bottom: none;
 }
@@ -1919,19 +1920,20 @@
     box-shadow: 0 0 1px 1px var(--primaryA);
 }
 
-.user-css-presentation .nav-tabs li a {
+.user-css-presentation .nav-tabs li.nav-item a.nav-link {
     background: var(--accentATransparent);
     color: var(--accentDMuted);
     box-shadow: 0 0 1px 1px var(--accentATransparent);
 }
 
-.user-css-presentation .nav-tabs li a:hover {
+.user-css-presentation .nav-tabs li.nav-item a.nav-link:hover {
     background: var(--primaryATransparent);
     color: var(--primaryDMuted);
     box-shadow: 0 0 1px 1px var(--primaryATransparent);
 }
 
-.user-css-presentation .nav-tabs li.active a {
+.user-css-presentation .nav-tabs li.active a.nav-link,
+.user-css-presentation .nav-tabs li.active a.nav-link:hover {
     background: var(--primaryD);
     border-color: var(--primaryD);
     color: var(--primary3Muted);

--- a/themes/galaxyanvil/css/style.css
+++ b/themes/galaxyanvil/css/style.css
@@ -676,6 +676,10 @@
     padding-left: 35px;
 }
 
+.user-css-presentation .article-title .pronunciation {
+    font-family: inherit;
+}
+
 .user-css-presentation .article-title-author {
     font-family: inherit;
     font-size: 1em;

--- a/themes/galaxyanvil/themes/midnight-dusk.css
+++ b/themes/galaxyanvil/themes/midnight-dusk.css
@@ -1,0 +1,146 @@
+/* Color Theme: Midnight Dusk */
+.user-css-presentation, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
+    /* Default Color */
+    --default1: #111121;
+    --default2: #222232;
+    --default3: #333343;
+    --default4: #444454;
+    --default5: #555565;
+    --default6: #666676;
+    --default7: #777787;
+    --default8: #888898;
+    --default9: #9999A9;
+    --defaultA: #AAAABA;
+    --defaultB: #BBBBCB;
+    --defaultC: #CCCCDC;
+    --defaultD: #DDDDED;
+    --defaultE: #EEEEFE;
+
+    --default1Muted: #111121;
+    --default2Muted: #222232;
+    --default3Muted: #333343;
+    --default4Muted: #444454;
+    --default5Muted: #555565;
+    --default6Muted: #666676;
+    --default7Muted: #777787;
+    --default8Muted: #888898;
+    --default9Muted: #9999A9;
+    --defaultAMuted: #AAAABA;
+    --defaultBMuted: #BBBBCB;
+    --defaultCMuted: #CCCCDC;
+    --defaultDMuted: #DDDDED;
+    --defaultEMuted: #EEEEFE;
+
+    --default1Transparent: rgba(17, 17, 33, 0.5);
+    --default2Transparent: rgba(34, 34, 50, 0.5);
+    --default3Transparent: rgba(51, 51, 67, 0.5);
+    --default4Transparent: rgba(68, 68, 84, 0.5);
+    --default5Transparent: rgba(85, 85, 101, 0.5);
+    --default6Transparent: rgba(102, 102, 118, 0.5);
+    --default7Transparent: rgba(119, 119, 135, 0.5);
+    --default8Transparent: rgba(136, 136, 152, 0.5);
+    --default9Transparent: rgba(153, 153, 169, 0.5);
+    --defaultATransparent: rgba(170, 170, 186, 0.5);
+    --defaultBTransparent: rgba(187, 187, 203, 0.5);
+    --defaultCTransparent: rgba(204, 204, 220, 0.5);
+    --defaultDTransparent: rgba(221, 221, 237, 0.5);
+    --defaultETransparent: rgba(238, 238, 254, 0.5);
+
+    /* Primary Color */
+    --primary1: #112111;
+    --primary2: #193019;
+    --primary3: #224222;
+    --primary4: #2A512A;
+    --primary5: #336333;
+    --primary6: #3C753C;
+    --primary7: #448444;
+    --primary8: #4E964E;
+    --primary9: #57A857;
+    --primaryA: #5FB75F;
+    --primaryB: #68C968;
+    --primaryC: #72DB72;
+    --primaryD: #79EA79;
+    --primaryE: #83FC83;
+
+    --primary1Muted: #112111;
+    --primary2Muted: #223222;
+    --primary3Muted: #334333;
+    --primary4Muted: #445444;
+    --primary5Muted: #556555;
+    --primary6Muted: #667666;
+    --primary7Muted: #778777;
+    --primary8Muted: #889888;
+    --primary9Muted: #99a999;
+    --primaryAMuted: #aabaaa;
+    --primaryBMuted: #bbcbbb;
+    --primaryCMuted: #ccdccc;
+    --primaryDMuted: #ddeddd;
+    --primaryEMuted: #eefeee;
+
+    --primary1Transparent: rgba(17, 33, 17, 0.5);
+    --primary2Transparent: rgba(25, 48, 25, 0.5);
+    --primary3Transparent: rgba(34, 66, 34, 0.5);
+    --primary4Transparent: rgba(42, 81, 42, 0.5);
+    --primary5Transparent: rgba(51, 99, 51, 0.5);
+    --primary6Transparent: rgba(60, 117, 60, 0.5);
+    --primary7Transparent: rgba(68, 132, 68, 0.5);
+    --primary8Transparent: rgba(78, 150, 78, 0.5);
+    --primary9Transparent: rgba(87, 168, 87, 0.5);
+    --primaryATransparent: rgba(95, 183, 95, 0.5);
+    --primaryBTransparent: rgba(104, 201, 104, 0.5);
+    --primaryCTransparent: rgba(114, 219, 114, 0.5);
+    --primaryDTransparent: rgba(121, 234, 121, 0.5);
+    --primaryETransparent: rgba(131, 252, 131, 0.5);
+
+    /* Accent Color */
+    --accent1: #112121;
+    --accent2: #223232;
+    --accent3: #334343;
+    --accent4: #445454;
+    --accent5: #556565;
+    --accent6: #667676;
+    --accent7: #778787;
+    --accent8: #889898;
+    --accent9: #99a9a9;
+    --accentA: #aababa;
+    --accentB: #bbcbcb;
+    --accentC: #ccdcdc;
+    --accentD: #ddeded;
+    --accentE: #eefefe;
+
+    --accent1Muted: #112121;
+    --accent2Muted: #223232;
+    --accent3Muted: #334343;
+    --accent4Muted: #445454;
+    --accent5Muted: #556565;
+    --accent6Muted: #667676;
+    --accent7Muted: #778787;
+    --accent8Muted: #889898;
+    --accent9Muted: #99a9a9;
+    --accentAMuted: #aababa;
+    --accentBMuted: #bbcbcb;
+    --accentCMuted: #ccdcdc;
+    --accentDMuted: #ddeded;
+    --accentEMuted: #eefefe;
+
+    --accent1Transparent: rgba(17, 33, 33, 0.5);
+    --accent2Transparent: rgba(34, 50, 50, 0.5);
+    --accent3Transparent: rgba(51, 67, 67, 0.5);
+    --accent4Transparent: rgba(68, 84, 84, 0.5);
+    --accent5Transparent: rgba(85, 101, 101, 0.5);
+    --accent6Transparent: rgba(102, 118, 118, 0.5);
+    --accent7Transparent: rgba(119, 135, 135, 0.5);
+    --accent8Transparent: rgba(136, 152, 152, 0.5);
+    --accent9Transparent: rgba(153, 169, 169, 0.5);
+    --accentATransparent: rgba(170, 186, 186, 0.5);
+    --accentBTransparent: rgba(187, 203, 201, 0.5);
+    --accentCTransparent: rgba(204, 220, 220, 0.5);
+    --accentDTransparent: rgba(221, 237, 237, 0.5);
+    --accentETransparent: rgba(238, 254, 254, 0.5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #85B98D; /* Used for h3 */
+    --midPrimaryAccent8: #6B9773; /* Used for h3 small */
+    --midDefaultAccentA: #AAB2BA; /* Used for h5 */
+    --midDefaultAccent8: #889098; /* Used for h5 small */
+}

--- a/themes/galaxyanvil/themes/monochrome-blue.css
+++ b/themes/galaxyanvil/themes/monochrome-blue.css
@@ -1,0 +1,146 @@
+/* Color Theme: Monochrome Blue */
+.user-css-presentation, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
+    /* Default Color */
+    --default1: #111921;
+    --default2: #222a32;
+    --default3: #333b43;
+    --default4: #444c54;
+    --default5: #555d65;
+    --default6: #666e76;
+    --default7: #777f87;
+    --default8: #889098;
+    --default9: #99a1a9;
+    --defaultA: #aab2ba;
+    --defaultB: #bbc3cb;
+    --defaultC: #ccd4dc;
+    --defaultD: #dde5ed;
+    --defaultE: #eef6fe;
+
+    --default1Muted: #111921;
+    --default2Muted: #222a32;
+    --default3Muted: #333b43;
+    --default4Muted: #444c54;
+    --default5Muted: #555d65;
+    --default6Muted: #666e76;
+    --default7Muted: #777f87;
+    --default8Muted: #889098;
+    --default9Muted: #99a1a9;
+    --defaultAMuted: #aab2ba;
+    --defaultBMuted: #bbc3cb;
+    --defaultCMuted: #ccd4dc;
+    --defaultDMuted: #dde5ed;
+    --defaultEMuted: #eef6fe;
+
+    --default1Transparent: rgba(17, 25, 33, .5);
+    --default2Transparent: rgba(34, 42, 50, .5);
+    --default3Transparent: rgba(51, 59, 67, .5);
+    --default4Transparent: rgba(68, 76, 84, .5);
+    --default5Transparent: rgba(85, 93, 101, .5);
+    --default6Transparent: rgba(102, 110, 118, .5);
+    --default7Transparent: rgba(119, 127, 135, .5);
+    --default8Transparent: rgba(136, 144, 152, .5);
+    --default9Transparent: rgba(153, 161, 169, .5);
+    --defaultATransparent: rgba(170, 178, 186, .5);
+    --defaultBTransparent: rgba(187, 195, 203, .5);
+    --defaultCTransparent: rgba(204, 212, 220, .5);
+    --defaultDTransparent: rgba(221, 229, 237, .5);
+    --defaultETransparent: rgba(238, 246, 254, .5);
+
+    /* Primary Color */
+    --primary1: #000f1e;
+    --primary2: #001830;
+    --primary3: #002142;
+    --primary4: #002951;
+    --primary5: #003263;
+    --primary6: #003b75;
+    --primary7: #004284;
+    --primary8: #004b96;
+    --primary9: #0054a8;
+    --primaryA: #005cb7;
+    --primaryB: #0065c9;
+    --primaryC: #006edb;
+    --primaryD: #0075ea;
+    --primaryE: #007efc;
+
+    --primary1Muted: #111921;
+    --primary2Muted: #222a32;
+    --primary3Muted: #333b43;
+    --primary4Muted: #444c54;
+    --primary5Muted: #555d65;
+    --primary6Muted: #666e76;
+    --primary7Muted: #777f87;
+    --primary8Muted: #889098;
+    --primary9Muted: #99a1a9;
+    --primaryAMuted: #aab2ba;
+    --primaryBMuted: #bbc3cb;
+    --primaryCMuted: #ccd4dc;
+    --primaryDMuted: #dde5ed;
+    --primaryEMuted: #eef6fe;
+
+    --primary1Transparent: rgba(0, 15, 30, .5);
+    --primary2Transparent: rgba(0, 24, 48, .5);
+    --primary3Transparent: rgba(0, 33, 66, .5);
+    --primary4Transparent: rgba(0, 41, 81, .5);
+    --primary5Transparent: rgba(0, 50, 99, .5);
+    --primary6Transparent: rgba(0, 59, 117, .5);
+    --primary7Transparent: rgba(0, 66, 132, .5);
+    --primary8Transparent: rgba(0, 75, 150, .5);
+    --primary9Transparent: rgba(0, 84, 168, .5);
+    --primaryATransparent: rgba(0, 92, 183, .5);
+    --primaryBTransparent: rgba(0, 101, 201, .5);
+    --primaryCTransparent: rgba(0, 110, 219, .5);
+    --primaryDTransparent: rgba(0, 117, 234, .5);
+    --primaryETransparent: rgba(0, 126, 252, .5);
+
+    /* Accent Color */
+    --accent1: #111921;
+    --accent2: #192530;
+    --accent3: #223242;
+    --accent4: #2a3e51;
+    --accent5: #334b63;
+    --accent6: #3c5975;
+    --accent7: #446484;
+    --accent8: #4e7296;
+    --accent9: #758fa8;
+    --accentA: #5f8bb7;
+    --accentB: #6899c9;
+    --accentC: #72a7db;
+    --accentD: #79b2ea;
+    --accentE: #83c0fc;
+
+    --accent1Muted: #111921;
+    --accent2Muted: #222a32;
+    --accent3Muted: #333b43;
+    --accent4Muted: #444c54;
+    --accent5Muted: #555d65;
+    --accent6Muted: #666e76;
+    --accent7Muted: #777f87;
+    --accent8Muted: #889098;
+    --accent9Muted: #99a1a9;
+    --accentAMuted: #aab2ba;
+    --accentBMuted: #bbc3cb;
+    --accentCMuted: #ccd4dc;
+    --accentDMuted: #dde5ed;
+    --accentEMuted: #eef6fe;
+
+    --accent1Transparent: rgba(17, 25, 33, .5);
+    --accent2Transparent: rgba(25, 37, 48, .5);
+    --accent3Transparent: rgba(34, 50, 66, .5);
+    --accent4Transparent: rgba(42, 62, 81, .5);
+    --accent5Transparent: rgba(51, 75, 99, .5);
+    --accent6Transparent: rgba(60, 89, 117, .5);
+    --accent7Transparent: rgba(68, 100, 132, .5);
+    --accent8Transparent: rgba(78, 114, 150, .5);
+    --accent9Transparent: rgba(117, 143, 168, .5);
+    --accentATransparent: rgba(95, 139, 183, .5);
+    --accentBTransparent: rgba(104, 153, 201, .5);
+    --accentCTransparent: rgba(114, 167, 219, .5);
+    --accentDTransparent: rgba(121, 178, 234, .5);
+    --accentETransparent: rgba(131, 192, 252, .5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #3074b7; /* Used for h3 */
+    --midPrimaryAccent8: #275f96; /* Used for h3 small */
+    --midDefaultAccentA: #859fb9; /* Used for h5 */
+    --midDefaultAccent8: #6b8197; /* Used for h5 small */
+}

--- a/themes/galaxyanvil/themes/monochrome-green.css
+++ b/themes/galaxyanvil/themes/monochrome-green.css
@@ -1,0 +1,146 @@
+/* Theme: Monochrome Green */
+.user-css-presentation, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
+    /* Default Color */
+    --default1: #112111;
+    --default2: #223222;
+    --default3: #334333;
+    --default4: #445444;
+    --default5: #556555;
+    --default6: #667666;
+    --default7: #778777;
+    --default8: #889888;
+    --default9: #99a999;
+    --defaultA: #aabaaa;
+    --defaultB: #bbcbbb;
+    --defaultC: #ccdccc;
+    --defaultD: #ddeddd;
+    --defaultE: #eefeee;
+
+    --default1Muted: #112111;
+    --default2Muted: #223222;
+    --default3Muted: #334333;
+    --default4Muted: #445444;
+    --default5Muted: #556555;
+    --default6Muted: #667666;
+    --default7Muted: #778777;
+    --default8Muted: #889888;
+    --default9Muted: #99a999;
+    --defaultAMuted: #aabaaa;
+    --defaultBMuted: #bbcbbb;
+    --defaultCMuted: #ccdccc;
+    --defaultDMuted: #ddeddd;
+    --defaultEMuted: #eefeee;
+
+    --default1Transparent: rgba(17, 33, 17, .5);
+    --default2Transparent: rgba(34, 50, 34, .5);
+    --default3Transparent: rgba(51, 67, 51, .5);
+    --default4Transparent: rgba(68, 84, 68, .5);
+    --default5Transparent: rgba(85, 101, 85, .5);
+    --default6Transparent: rgba(102, 118, 102, .5);
+    --default7Transparent: rgba(119, 135, 119, .5);
+    --default8Transparent: rgba(136, 152, 136, .5);
+    --default9Transparent: rgba(153, 169, 153, .5);
+    --defaultATransparent: rgba(170, 186, 170, .5);
+    --defaultBTransparent: rgba(187, 203, 187, .5);
+    --defaultCTransparent: rgba(204, 220, 204, .5);
+    --defaultDTransparent: rgba(221, 237, 221, .5);
+    --defaultETransparent: rgba(238, 254, 238, .5);
+
+    /* Primary Color */
+    --primary1: #001e00;
+    --primary2: #003000;
+    --primary3: #004200;
+    --primary4: #005100;
+    --primary5: #006300;
+    --primary6: #007500;
+    --primary7: #008400;
+    --primary8: #009600;
+    --primary9: #00a800;
+    --primaryA: #00b700;
+    --primaryB: #00c900;
+    --primaryC: #00db00;
+    --primaryD: #00ea00;
+    --primaryE: #00fc00;
+
+    --primary1Muted: #112111;
+    --primary2Muted: #223222;
+    --primary3Muted: #334333;
+    --primary4Muted: #445444;
+    --primary5Muted: #556555;
+    --primary6Muted: #667666;
+    --primary7Muted: #778777;
+    --primary8Muted: #889888;
+    --primary9Muted: #99a999;
+    --primaryAMuted: #aabaaa;
+    --primaryBMuted: #bbcbbb;
+    --primaryCMuted: #ccdccc;
+    --primaryDMuted: #ddeddd;
+    --primaryEMuted: #eefeee;
+
+    --primary1Transparent: rgba(0, 30, 0, .5);
+    --primary2Transparent: rgba(0, 48, 0, .5);
+    --primary3Transparent: rgba(0, 66, 0, .5);
+    --primary4Transparent: rgba(0, 81, 0, .5);
+    --primary5Transparent: rgba(0, 99, 0, .5);
+    --primary6Transparent: rgba(0, 117, 0, .5);
+    --primary7Transparent: rgba(0, 132, 0, .5);
+    --primary8Transparent: rgba(0, 150, 0, .5);
+    --primary9Transparent: rgba(0, 168, 0, .5);
+    --primaryATransparent: rgba(0, 183, 0, .5);
+    --primaryBTransparent: rgba(0, 201, 0, .5);
+    --primaryCTransparent: rgba(0, 219, 0, .5);
+    --primaryDTransparent: rgba(0, 234, 0, .5);
+    --primaryETransparent: rgba(0, 252, 0, .5);
+
+    /* Accent Color */
+    --accent1: #112111;
+    --accent2: #193019;
+    --accent3: #224222;
+    --accent4: #2a512a;
+    --accent5: #336333;
+    --accent6: #3c753c;
+    --accent7: #448444;
+    --accent8: #4e964e;
+    --accent9: #75a875;
+    --accentA: #5fb75f;
+    --accentB: #68c968;
+    --accentC: #72db72;
+    --accentD: #79ea79;
+    --accentE: #83fc83;
+
+    --accent1Muted: #112111;
+    --accent2Muted: #223222;
+    --accent3Muted: #334333;
+    --accent4Muted: #445444;
+    --accent5Muted: #556555;
+    --accent6Muted: #667666;
+    --accent7Muted: #778777;
+    --accent8Muted: #889888;
+    --accent9Muted: #99a999;
+    --accentAMuted: #aabaaa;
+    --accentBMuted: #bbcbbb;
+    --accentCMuted: #ccdccc;
+    --accentDMuted: #ddeddd;
+    --accentEMuted: #eefeee;
+
+    --accent1Transparent: rgba(17, 33, 17, .5);
+    --accent2Transparent: rgba(25, 48, 25, .5);
+    --accent3Transparent: rgba(34, 66, 34, .5);
+    --accent4Transparent: rgba(42, 81, 42, .5);
+    --accent5Transparent: rgba(51, 99, 51, .5);
+    --accent6Transparent: rgba(60, 117, 60, .5);
+    --accent7Transparent: rgba(68, 132, 68, .5);
+    --accent8Transparent: rgba(78, 150, 78, .5);
+    --accent9Transparent: rgba(117, 168, 117, .5);
+    --accentATransparent: rgba(95, 183, 95, .5);
+    --accentBTransparent: rgba(104, 201, 104, .5);
+    --accentCTransparent: rgba(114, 219, 114, .5);
+    --accentDTransparent: rgba(121, 234, 121, .5);
+    --accentETransparent: rgba(131, 252, 131, .5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #30b730; /* Used for h3 */
+    --midPrimaryAccent8: #279627; /* Used for h3 small */
+    --midDefaultAccentA: #85b985; /* Used for h5 */
+    --midDefaultAccent8: #6b976b; /* Used for h5 small */
+}

--- a/themes/galaxyanvil/themes/monochrome-mint.css
+++ b/themes/galaxyanvil/themes/monochrome-mint.css
@@ -1,0 +1,145 @@
+.user-css-presentation, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
+    /* Default Color */
+    --default1: #112119;
+    --default2: #22322a;
+    --default3: #33433b;
+    --default4: #44544c;
+    --default5: #55655d;
+    --default6: #66766e;
+    --default7: #77877f;
+    --default8: #889890;
+    --default9: #99a9a1;
+    --defaultA: #aabab2;
+    --defaultB: #bbcbc3;
+    --defaultC: #ccdcd4;
+    --defaultD: #ddede5;
+    --defaultE: #eefef6;
+
+    --default1Muted: #112119;
+    --default2Muted: #22322a;
+    --default3Muted: #33433b;
+    --default4Muted: #44544c;
+    --default5Muted: #55655d;
+    --default6Muted: #66766e;
+    --default7Muted: #77877f;
+    --default8Muted: #889890;
+    --default9Muted: #99a9a1;
+    --defaultAMuted: #aabab2;
+    --defaultBMuted: #bbcbc3;
+    --defaultCMuted: #ccdcd4;
+    --defaultDMuted: #ddede5;
+    --defaultEMuted: #eefef6;
+
+    --default1Transparent: rgba(17, 33, 25, .5);
+    --default2Transparent: rgba(34, 50, 42, .5);
+    --default3Transparent: rgba(51, 67, 59, .5);
+    --default4Transparent: rgba(68, 84, 76, .5);
+    --default5Transparent: rgba(85, 101, 93, .5);
+    --default6Transparent: rgba(102, 118, 110, .5);
+    --default7Transparent: rgba(119, 135, 127, .5);
+    --default8Transparent: rgba(136, 152, 144, .5);
+    --default9Transparent: rgba(153, 169, 161, .5);
+    --defaultATransparent: rgba(170, 186, 178, .5);
+    --defaultBTransparent: rgba(187, 203, 195, .5);
+    --defaultCTransparent: rgba(204, 220, 212, .5);
+    --defaultDTransparent: rgba(221, 237, 229, .5);
+    --defaultETransparent: rgba(238, 254, 246, .5);
+
+    /* Primary Color */
+    --primary1: #001e0f;
+    --primary2: #003018;
+    --primary3: #004221;
+    --primary4: #005129;
+    --primary5: #006332;
+    --primary6: #00753b;
+    --primary7: #008442;
+    --primary8: #00964b;
+    --primary9: #00a854;
+    --primaryA: #00b75c;
+    --primaryB: #00c965;
+    --primaryC: #00db6e;
+    --primaryD: #00ea75;
+    --primaryE: #00fc7e;
+
+    --primary1Muted: #112119;
+    --primary2Muted: #22322a;
+    --primary3Muted: #33433b;
+    --primary4Muted: #44544c;
+    --primary5Muted: #55655d;
+    --primary6Muted: #66766e;
+    --primary7Muted: #77877f;
+    --primary8Muted: #889890;
+    --primary9Muted: #99a9a1;
+    --primaryAMuted: #aabab2;
+    --primaryBMuted: #bbcbc3;
+    --primaryCMuted: #ccdcd4;
+    --primaryDMuted: #ddede5;
+    --primaryEMuted: #eefef6;
+
+    --primary1Transparent: rgba(0, 30, 15, .5);
+    --primary2Transparent: rgba(0, 48, 24, .5);
+    --primary3Transparent: rgba(0, 66, 33, .5);
+    --primary4Transparent: rgba(0, 81, 41, .5);
+    --primary5Transparent: rgba(0, 99, 50, .5);
+    --primary6Transparent: rgba(0, 117, 59, .5);
+    --primary7Transparent: rgba(0, 132, 66, .5);
+    --primary8Transparent: rgba(0, 150, 75, .5);
+    --primary9Transparent: rgba(0, 168, 84, .5);
+    --primaryATransparent: rgba(0, 183, 92, .5);
+    --primaryBTransparent: rgba(0, 201, 101, .5);
+    --primaryCTransparent: rgba(0, 219, 110, .5);
+    --primaryDTransparent: rgba(0, 234, 117, .5);
+    --primaryETransparent: rgba(0, 252, 126, .5);
+
+    /* Accent Color */
+    --accent1: #112119;
+    --accent2: #193025;
+    --accent3: #224232;
+    --accent4: #2a513e;
+    --accent5: #33634b;
+    --accent6: #3c7559;
+    --accent7: #448464;
+    --accent8: #4e9672;
+    --accent9: #75a88f;
+    --accentA: #5fb78b;
+    --accentB: #68c999;
+    --accentC: #72dba7;
+    --accentD: #79eab2;
+    --accentE: #83fcc0;
+
+    --accent1Muted: #112119;
+    --accent2Muted: #22322a;
+    --accent3Muted: #33433b;
+    --accent4Muted: #44544c;
+    --accent5Muted: #55655d;
+    --accent6Muted: #66766e;
+    --accent7Muted: #77877f;
+    --accent8Muted: #889890;
+    --accent9Muted: #99a9a1;
+    --accentAMuted: #aabab2;
+    --accentBMuted: #bbcbc3;
+    --accentCMuted: #ccdcd4;
+    --accentDMuted: #ddede5;
+    --accentEMuted: #eefef6;
+
+    --accent1Transparent: rgba(17, 33, 25, .5);
+    --accent2Transparent: rgba(25, 48, 37, .5);
+    --accent3Transparent: rgba(34, 66, 50, .5);
+    --accent4Transparent: rgba(42, 81, 62, .5);
+    --accent5Transparent: rgba(51, 99, 75, .5);
+    --accent6Transparent: rgba(60, 117, 89, .5);
+    --accent7Transparent: rgba(68, 132, 100, .5);
+    --accent8Transparent: rgba(78, 150, 114, .5);
+    --accent9Transparent: rgba(117, 168, 143, .5);
+    --accentATransparent: rgba(95, 183, 139, .5);
+    --accentBTransparent: rgba(104, 201, 153, .5);
+    --accentCTransparent: rgba(114, 219, 167, .5);
+    --accentDTransparent: rgba(121, 234, 178, .5);
+    --accentETransparent: rgba(131, 252, 192, .5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #30b774; /* Used for h3 */
+    --midPrimaryAccent8: #27965f; /* Used for h3 small */
+    --midDefaultAccentA: #85b99f; /* Used for h5 */
+    --midDefaultAccent8: #6b9781; /* Used for h5 small */
+}

--- a/themes/galaxyanvil/themes/monochrome-red.css
+++ b/themes/galaxyanvil/themes/monochrome-red.css
@@ -1,0 +1,146 @@
+/* Color Theme: Monochrome Red */
+.user-css-presentation, .user-css-presentation .user-css-extended, .user-css-map-sidebar, .user-css-map, .map-wrapper {
+    /* Default Color */
+    --default1: #211111;
+    --default2: #322222;
+    --default3: #433333;
+    --default4: #544444;
+    --default5: #655555;
+    --default6: #766666;
+    --default7: #877777;
+    --default8: #988888;
+    --default9: #a99999;
+    --defaultA: #baaaaa;
+    --defaultB: #cbbbbb;
+    --defaultC: #dccccc;
+    --defaultD: #eddddd;
+    --defaultE: #feeeee;
+
+    --default1Muted: #211111;
+    --default2Muted: #322222;
+    --default3Muted: #433333;
+    --default4Muted: #544444;
+    --default5Muted: #655555;
+    --default6Muted: #766666;
+    --default7Muted: #877777;
+    --default8Muted: #988888;
+    --default9Muted: #a99999;
+    --defaultAMuted: #baaaaa;
+    --defaultBMuted: #cbbbbb;
+    --defaultCMuted: #dccccc;
+    --defaultDMuted: #eddddd;
+    --defaultEMuted: #feeeee;
+
+    --default1Transparent: rgba(33, 17, 17, .5);
+    --default2Transparent: rgba(50, 34, 34, .5);
+    --default3Transparent: rgba(67, 51, 51, .5);
+    --default4Transparent: rgba(84, 68, 68, .5);
+    --default5Transparent: rgba(101, 85, 85, .5);
+    --default6Transparent: rgba(118, 102, 102, .5);
+    --default7Transparent: rgba(135, 119, 119, .5);
+    --default8Transparent: rgba(152, 136, 136, .5);
+    --default9Transparent: rgba(169, 153, 153, .5);
+    --defaultATransparent: rgba(186, 170, 170, .5);
+    --defaultBTransparent: rgba(203, 187, 187, .5);
+    --defaultCTransparent: rgba(220, 204, 204, .5);
+    --defaultDTransparent: rgba(237, 221, 221, .5);
+    --defaultETransparent: rgba(254, 238, 238, .5);
+
+    /* Primary Color */
+    --primary1: #1e0000;
+    --primary2: #300000;
+    --primary3: #420000;
+    --primary4: #510000;
+    --primary5: #630000;
+    --primary6: #750000;
+    --primary7: #840000;
+    --primary8: #960000;
+    --primary9: #a80000;
+    --primaryA: #b70000;
+    --primaryB: #c90000;
+    --primaryC: #db0000;
+    --primaryD: #ea0000;
+    --primaryE: #fc0000;
+
+    --primary1Muted: #211111;
+    --primary2Muted: #322222;
+    --primary3Muted: #433333;
+    --primary4Muted: #544444;
+    --primary5Muted: #655555;
+    --primary6Muted: #766666;
+    --primary7Muted: #877777;
+    --primary8Muted: #988888;
+    --primary9Muted: #a99999;
+    --primaryAMuted: #baaaaa;
+    --primaryBMuted: #cbbbbb;
+    --primaryCMuted: #dccccc;
+    --primaryDMuted: #eddddd;
+    --primaryEMuted: #feeeee;
+
+    --primary1Transparent: rgba(30, 0, 0, .5);
+    --primary2Transparent: rgba(48, 0, 0, .5);
+    --primary3Transparent: rgba(66, 0, 0, .5);
+    --primary4Transparent: rgba(81, 0, 0, .5);
+    --primary5Transparent: rgba(99, 0, 0, .5);
+    --primary6Transparent: rgba(117, 0, 0, .5);
+    --primary7Transparent: rgba(132, 0, 0, .5);
+    --primary8Transparent: rgba(150, 0, 0, .5);
+    --primary9Transparent: rgba(168, 0, 0, .5);
+    --primaryATransparent: rgba(183, 0, 0, .5);
+    --primaryBTransparent: rgba(201, 0, 0, .5);
+    --primaryCTransparent: rgba(219, 0, 0, .5);
+    --primaryDTransparent: rgba(234, 0, 0, .5);
+    --primaryETransparent: rgba(252, 0, 0, .5);
+
+    /* Accent Color */
+    --accent1: #211111;
+    --accent2: #301919;
+    --accent3: #422222;
+    --accent4: #512a2a;
+    --accent5: #633333;
+    --accent6: #753c3c;
+    --accent7: #844444;
+    --accent8: #964e4e;
+    --accent9: #a87575;
+    --accentA: #b75f5f;
+    --accentB: #c96868;
+    --accentC: #db7272;
+    --accentD: #ea7979;
+    --accentE: #fc8383;
+
+    --accent1Muted: #211111;
+    --accent2Muted: #322222;
+    --accent3Muted: #433333;
+    --accent4Muted: #544444;
+    --accent5Muted: #655555;
+    --accent6Muted: #766666;
+    --accent7Muted: #877777;
+    --accent8Muted: #988888;
+    --accent9Muted: #a99999;
+    --accentAMuted: #baaaaa;
+    --accentBMuted: #cbbbbb;
+    --accentCMuted: #dccccc;
+    --accentDMuted: #eddddd;
+    --accentEMuted: #feeeee;
+
+    --accent1Transparent: rgba(33, 17, 17, .5);
+    --accent2Transparent: rgba(48, 25, 25, .5);
+    --accent3Transparent: rgba(66, 34, 34, .5);
+    --accent4Transparent: rgba(81, 42, 42, .5);
+    --accent5Transparent: rgba(99, 51, 51, .5);
+    --accent6Transparent: rgba(117, 60, 60, .5);
+    --accent7Transparent: rgba(132, 68, 68, .5);
+    --accent8Transparent: rgba(150, 78, 78, .5);
+    --accent9Transparent: rgba(168, 117, 117, .5);
+    --accentATransparent: rgba(183, 95, 95, .5);
+    --accentBTransparent: rgba(201, 104, 104, .5);
+    --accentCTransparent: rgba(219, 114, 114, .5);
+    --accentDTransparent: rgba(234, 121, 121, .5);
+    --accentETransparent: rgba(252, 131, 131, .5);
+
+    /* Specialty Colors */
+    --midPrimaryAccentA: #b73030; /* Used for h3 */
+    --midPrimaryAccent8: #962727; /* Used for h3 small */
+    --midDefaultAccentA: #b98585; /* Used for h5 */
+    --midDefaultAccent8: #976b6b; /* Used for h5 small */
+}


### PR DESCRIPTION
## [1.6.0] - 2024-10-15
### Added
 - Support for WorldAnvil's `articletoc` bbcode.
   - Additional styling when used within `.panel-toc .panel-body` containers.
 - Support for the World Codex popup menu.

### Fixed
 - Fixes the pronunciation text not inheriting the article title's font family.
 - Fixes navigation tab colors and contrast (These are tab buttons primarily visible in the article metadata footer).
 - Fixes the presentation page being uninteractable once the World Codex is opened.
 - Fixes the rendering of cell borders for the right-hand middle cells in 3-column rows under `.row-border-group`.